### PR TITLE
Implement shared and private domains

### DIFF
--- a/main/cloudfoundry_client/client.py
+++ b/main/cloudfoundry_client/client.py
@@ -26,13 +26,12 @@ class Info:
 
 
 class CloudFoundryClient(CredentialManager):
-    def __init__(self, target_endpoint, client_id='cf', client_secret='', proxy=None, skip_verification=False):
-        self.info = self._get_info(target_endpoint, proxy, skip_verification)
+    def __init__(self, target_endpoint, client_id='cf', client_secret='', proxy=None, verify=True):
+        self.info = self._get_info(target_endpoint, proxy, verify=verify)
         if not self.info.api_version.startswith('2.'):
             raise AssertionError('Only version 2 is supported for now. Found %s' % self.info.api_version)
-
         service_informations = ServiceInformation(None, '%s/oauth/token' % self.info.authorization_endpoint,
-                                                  client_id, client_secret, [], skip_verification)
+                                                  client_id, client_secret, [], verify)
         super(CloudFoundryClient, self).__init__(service_informations, proxy)
         CredentialManager.__init__(self, service_informations, proxy)
         self.service_plans = ServicePlanManager(target_endpoint, self)
@@ -62,11 +61,11 @@ class CloudFoundryClient(CredentialManager):
             return self._doppler
 
     @staticmethod
-    def _get_info(target_endpoint, proxy=None, skip_verification=False):
+    def _get_info(target_endpoint, proxy=None, verify=True):
         info_response = CloudFoundryClient._check_response(requests.get('%s/v2/info' % target_endpoint,
                                                                         proxies=proxy if proxy is not None else dict(
                                                                             http='', https=''),
-                                                                        verify=not skip_verification))
+                                                                        verify=verify))
         info = info_response.json()
         return Info(info['api_version'],
                     info['authorization_endpoint'],

--- a/main/cloudfoundry_client/client.py
+++ b/main/cloudfoundry_client/client.py
@@ -46,6 +46,8 @@ class CloudFoundryClient(CredentialManager):
         self.spaces = EntityManager(target_endpoint, self, '/v2/spaces')
         self.services = EntityManager(target_endpoint, self, '/v2/services')
         self.routes = EntityManager(target_endpoint, self, '/v2/routes')
+        self.shared_domains = EntityManager(target_endpoint, self, '/v2/shared_domains')
+        self.private_domains = EntityManager(target_endpoint, self, '/v2/private_domains')
         self._doppler = DopplerClient(self.info.doppler_endpoint,
                                       self.proxies[
                                           'http' if self.info.doppler_endpoint.startswith('ws://') else 'https'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 protobuf==3.6.1
-oauth2-client==0.0.21
+oauth2-client==1.0.0
 websocket-client==0.53.0


### PR DESCRIPTION
Hi there,

this patch adds the shared_domains and private_domains endpoints and changes the behaviour of the client to use verify in a similar way the underlying requests library uses it. That way it's possible to pass self signed certificates in client code.

Would you take a look and let me know if you're interested in those changes and what would be needed to get them in shape to be merged into the master branch?

Cheers,

Diogo