### PR TITLE
CloudFoundryClient: Added token_path to __init__

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 protobuf==3.6.1
-oauth2-client==1.0.0
+oauth2-client==1.1.0
 websocket-client==0.53.0


### PR DESCRIPTION
Instead of hard-coding the token endpoint to be {target_endpoint}/oauth/token added an argument to allow customization of the token path so that the token endpoint will be {target_endpoint}{token_path}. This is useful when wanting to provide a login hint to UAA. See https://docs.cloudfoundry.org/api/uaa/version/4.24.0/index.html#browser-flow for other options.