### PR TITLE
Fix/file helper

### DIFF
--- a/main/cloudfoundry_client/operations/push/file_helper.py
+++ b/main/cloudfoundry_client/operations/push/file_helper.py
@@ -23,8 +23,9 @@ class FileHelper(object):
         with zipfile.ZipFile(path, 'r') as zip_ref:
             for entry in zip_ref.namelist():
                 filename = os.path.basename(entry)
-                if not filename and not os.path.isdir(os.path.join(tmp_dir, entry)):
-                    os.makedirs(os.path.join(tmp_dir, entry))
+                path_to_create = os.path.join(tmp_dir, entry)
+                if not filename and not os.path.isdir(path_to_create):
+                    os.makedirs(path_to_create)
                 else:
                     zip_ref.extract(entry, tmp_dir)
 

--- a/main/cloudfoundry_client/operations/push/file_helper.py
+++ b/main/cloudfoundry_client/operations/push/file_helper.py
@@ -23,8 +23,8 @@ class FileHelper(object):
         with zipfile.ZipFile(path, 'r') as zip_ref:
             for entry in zip_ref.namelist():
                 filename = os.path.basename(entry)
-                if not filename:
-                    os.makedirs(os.path.join(tmp_dir, entry), exist_ok=True)
+                if not filename and not os.path.isdir(os.path.join(tmp_dir, entry)):
+                    os.makedirs(os.path.join(tmp_dir, entry))
                 else:
                     zip_ref.extract(entry, tmp_dir)
 

--- a/test/operations/push/test_file_helper.py
+++ b/test/operations/push/test_file_helper.py
@@ -1,0 +1,46 @@
+import os
+import shutil
+import tempfile
+import zipfile
+from unittest import TestCase
+
+from cloudfoundry_client.operations.push.file_helper import FileHelper
+
+
+class TestUnzipHelper(TestCase):
+    def setUp(self):
+        self.input_dirpath = self.zip_some_data()
+        self.output_dirpath = tempfile.mkdtemp()
+
+    def test_unzip(self):
+        self.unzip()
+        self.assertFileUnzipped()
+
+    def test_unzip_with_existing_output_subdir(self):
+        os.makedirs(self.output_dirpath + '/some_dir/subdir')
+        self.unzip()
+
+        self.assertFileUnzipped()
+
+    def unzip(self):
+        FileHelper.unzip(self.input_dirpath + '/myzip.zip', self.output_dirpath)
+
+    def zip_some_data(self):
+        input_dirpath = self.prepare_data_to_zip()
+        with zipfile.ZipFile(input_dirpath + '/myzip.zip', 'w', zipfile.ZIP_DEFLATED) as myzip:
+            myzip.write(input_dirpath + '/file.txt', 'file.txt')
+            myzip.write(input_dirpath + '/some_dir', 'some_dir')
+            myzip.write(input_dirpath + '/some_dir/subdir', 'some_dir/subdir')
+        return input_dirpath
+
+    def prepare_data_to_zip(self):
+        input_dirpath = tempfile.mkdtemp()
+        shutil.copyfile(__file__, input_dirpath + '/file.txt')
+        os.makedirs(input_dirpath + '/some_dir/subdir')
+        shutil.copyfile(__file__, input_dirpath + '/some_dir/file.txt')
+        return input_dirpath
+
+    def assertFileUnzipped(self):
+        self.assertTrue(os.path.isfile(self.output_dirpath + '/file.txt'))
+        self.assertTrue(os.path.isdir(self.output_dirpath + '/some_dir'))
+        self.assertTrue(os.path.isdir(self.output_dirpath + '/some_dir/subdir'))


### PR DESCRIPTION
Hi,

Here is a quick fix and its unit tests to make the FileHelper.unzip() method works with Python 2: in the current version of the library, the push operation doesn't work because of this error.

The original error is:

```
TypeError: makedirs() got an unexpected keyword argument 'exist_ok'
```

To summarize, the *exist_ok* argument doesn't exist in the Python 2 version of *makedirs()*.

Best regards,
Fouad