### PR TITLE
Give the possibility to specify a binding name at creation

### DIFF
--- a/main/cloudfoundry_client/v2/service_bindings.py
+++ b/main/cloudfoundry_client/v2/service_bindings.py
@@ -5,9 +5,10 @@ class ServiceBindingManager(EntityManager):
     def __init__(self, target_endpoint, client):
         super(ServiceBindingManager, self).__init__(target_endpoint, client, '/v2/service_bindings')
 
-    def create(self, app_guid, instance_guid, parameters=None):
+    def create(self, app_guid, instance_guid, parameters=None, binding_name=None):
         request = dict(app_guid=app_guid,
-                       service_instance_guid=instance_guid)
+                       service_instance_guid=instance_guid,
+                       name=binding_name)
         if parameters is None:
             request['parameters'] = {}
         else:

--- a/test/v2/test_service_bindings.py
+++ b/test/v2/test_service_bindings.py
@@ -43,14 +43,16 @@ class TestServiceBindings(unittest.TestCase, AbstractTestCase):
             CREATED,
             None,
             'v2', 'service_bindings', 'POST_response.json')
-        service_bindiing = self.client.v2.service_bindings.create('app_guid', 'instance_guid',
-                                                               dict(the_service_broker='wants this object'))
+        service_binding = self.client.v2.service_bindings.create('app_guid', 'instance_guid',
+                                                               dict(the_service_broker='wants this object'),
+                                                                 'binding_name')
         self.client.post.assert_called_with(self.client.post.return_value.url,
                                             json=dict(app_guid='app_guid',
                                                       service_instance_guid='instance_guid',
+                                                      name='binding_name',
                                                       parameters=dict(
                                                           the_service_broker='wants this object')))
-        self.assertIsNotNone(service_bindiing)
+        self.assertIsNotNone(service_binding)
 
     def test_delete(self):
         self.client.delete.return_value = mock_response(


### PR DESCRIPTION
Hi,

It would be convenient (at least for me 😃) if we could specify the name of a binding when creating one.

I've added this possibility in this pull request: the name argument is optional and has been added at the end of the method to avoid breaking existing clients.

Best regards,
Fouad