### PR TITLE
Add env attribute for _Application

### DIFF
--- a/main/cloudfoundry_client/v2/apps.py
+++ b/main/cloudfoundry_client/v2/apps.py
@@ -24,6 +24,9 @@ class _Application(Entity):
     def stats(self):
         return self.client.v2.apps.get_stats(self['metadata']['guid'])
 
+    def env(self):
+        return self.client.v2.apps.get_env(self['metadata']['guid'])
+
     def summary(self):
         return self.client.v2.apps.get_summary(self['metadata']['guid'])
 


### PR DESCRIPTION
For equivalent usage of following command : `cf env APP_NAME`
method _Application.env() where _Application type = <class 'cloudfoundry_client.v2.apps._Application'>
