### PR TITLE
Service plan visibilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ main/sandbox.py
 integration/sandbox.py
 integration/resources/test.properties
 .eggs/
+.venv

--- a/README.rst
+++ b/README.rst
@@ -103,6 +103,7 @@ Available managers
 So far the implemented managers that are available are:
 
 - ``service_plans``
+- ``service_plan_visibilities``
 - ``service_instances``
 - ``service_keys``
 - ``service_bindings``

--- a/main/cloudfoundry_client/client.py
+++ b/main/cloudfoundry_client/client.py
@@ -17,6 +17,7 @@ from cloudfoundry_client.v2.service_bindings import ServiceBindingManager
 from cloudfoundry_client.v2.service_brokers import ServiceBrokerManager
 from cloudfoundry_client.v2.service_instances import ServiceInstanceManager
 from cloudfoundry_client.v2.service_keys import ServiceKeyManager
+from cloudfoundry_client.v2.service_plan_visibilities import ServicePlanVisibilityManager
 from cloudfoundry_client.v2.service_plans import ServicePlanManager
 from cloudfoundry_client.v3.apps import AppManager as AppManagerV3
 from cloudfoundry_client.v3.entities import EntityManager as EntityManagerV3
@@ -42,6 +43,7 @@ class V2(object):
         self.service_brokers = ServiceBrokerManager(target_endpoint, credential_manager)
         self.service_instances = ServiceInstanceManager(target_endpoint, credential_manager)
         self.service_keys = ServiceKeyManager(target_endpoint, credential_manager)
+        self.service_plan_visibilities = ServicePlanVisibilityManager(target_endpoint, credential_manager)
         self.service_plans = ServicePlanManager(target_endpoint, credential_manager)
         # Default implementations
         self.event = EventManager(target_endpoint, credential_manager)

--- a/main/cloudfoundry_client/main/main.py
+++ b/main/cloudfoundry_client/main/main.py
@@ -185,6 +185,10 @@ def main():
         CommandDomain(display_name='Service Broker', client_domain='service_brokers',
                       filter_list_parameters=['name', 'space_guid'],
                       allow_retrieve_by_name=True, allow_creation=True, allow_deletion=True),
+        # exception, the name is not only 'strip trailing "s" from domain name'
+        CommandDomain(display_name='Service Plan Visibilities', client_domain='service_plan_visibilities',
+                      filter_list_parameters=['organization_guid', 'service_plan_guid'], name_property=None,
+                      allow_retrieve_by_name=False, allow_creation=True, allow_deletion=True),
         CommandDomain(display_name='Buildpacks', client_domain='buildpacks',
                       filter_list_parameters=[], allow_retrieve_by_name=False,
                       allow_creation=False, allow_deletion=False),

--- a/main/cloudfoundry_client/v2/service_plan_visibilities.py
+++ b/main/cloudfoundry_client/v2/service_plan_visibilities.py
@@ -1,0 +1,21 @@
+from cloudfoundry_client.v2.entities import EntityManager
+
+
+class ServicePlanVisibilityManager(EntityManager):
+    def __init__(self, target_endpoint, client):
+        super(ServicePlanVisibilityManager, self).__init__(target_endpoint, client, '/v2/service_plan_visibilities')
+
+    def create(self, service_plan_guid, organization_guid):
+        request = self._request()
+        request['service_plan_guid'] = service_plan_guid
+        request['organization_guid'] = organization_guid
+        return super(ServicePlanVisibilityManager, self)._create(request)
+
+    def update(self, spv_guid, service_plan_guid, organization_guid):
+        request = self._request()
+        request['service_plan_guid'] = service_plan_guid
+        request['organization_guid'] = organization_guid
+        return super(ServicePlanVisibilityManager, self)._update(spv_guid, request)
+
+    def remove(self, spv_guid):
+        super(ServicePlanVisibilityManager, self)._remove(spv_guid)

--- a/test/fixtures/v2/service_plan_visibilities/GET_response.json
+++ b/test/fixtures/v2/service_plan_visibilities/GET_response.json
@@ -1,0 +1,22 @@
+{
+  "total_results": 1,
+  "total_pages": 1,
+  "prev_url": null,
+  "next_url": null,
+  "resources": [
+    {
+      "metadata": {
+        "guid": "d1b5ea55-f354-4f43-b52e-53045747adb9",
+        "url": "/v2/service_plan_visibilities/d1b5ea55-f354-4f43-b52e-53045747adb9",
+        "created_at": "2016-06-08T16:41:31Z",
+        "updated_at": "2016-06-08T16:41:26Z"
+      },
+      "entity": {
+        "service_plan_guid": "62cb572c-e9ca-4c9f-b822-8292db1d9a96",
+        "organization_guid": "81df84f3-8ce0-4c92-990a-3760b6ff66bd",
+        "service_plan_url": "/v2/service_plans/62cb572c-e9ca-4c9f-b822-8292db1d9a96",
+        "organization_url": "/v2/organizations/81df84f3-8ce0-4c92-990a-3760b6ff66bd"
+      }
+    }
+  ]
+}

--- a/test/fixtures/v2/service_plan_visibilities/GET_{id}_response.json
+++ b/test/fixtures/v2/service_plan_visibilities/GET_{id}_response.json
@@ -1,0 +1,14 @@
+{
+  "metadata": {
+    "guid": "a353104b-1290-418c-bc03-0e647afd0853",
+    "url": "/v2/service_plan_visibilities/a353104b-1290-418c-bc03-0e647afd0853",
+    "created_at": "2016-06-08T16:41:31Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "service_plan_guid": "2bf35919-3922-49f3-9e14-5fee035a1b05",
+    "organization_guid": "e02678c3-44fb-4c0c-bd45-9354053c0707",
+    "service_plan_url": "/v2/service_plans/2bf35919-3922-49f3-9e14-5fee035a1b05",
+    "organization_url": "/v2/organizations/e02678c3-44fb-4c0c-bd45-9354053c0707"
+  }
+}

--- a/test/fixtures/v2/service_plan_visibilities/POST_response.json
+++ b/test/fixtures/v2/service_plan_visibilities/POST_response.json
@@ -1,0 +1,14 @@
+{
+  "metadata": {
+    "guid": "f740b01a-4afe-4435-aedd-0a8308a7e7d6",
+    "url": "/v2/service_plan_visibilities/f740b01a-4afe-4435-aedd-0a8308a7e7d6",
+    "created_at": "2016-06-08T16:41:31Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "service_plan_guid": "ab5780a9-ac8e-4412-9496-4512e865011a",
+    "organization_guid": "55d0ff39-dac9-431f-ba6d-83f37381f1c3",
+    "service_plan_url": "/v2/service_plans/ab5780a9-ac8e-4412-9496-4512e865011a",
+    "organization_url": "/v2/organizations/55d0ff39-dac9-431f-ba6d-83f37381f1c3"
+  }
+}

--- a/test/fixtures/v2/service_plan_visibilities/PUT_{id}_response.json
+++ b/test/fixtures/v2/service_plan_visibilities/PUT_{id}_response.json
@@ -1,0 +1,14 @@
+{
+  "metadata": {
+    "guid": "886bf17c-1e54-426c-9a66-6cc915784e73",
+    "url": "/v2/service_plan_visibilities/886bf17c-1e54-426c-9a66-6cc915784e73",
+    "created_at": "2016-06-08T16:41:31Z",
+    "updated_at": "2016-06-08T16:41:31Z"
+  },
+  "entity": {
+    "service_plan_guid": "522fb1a6-5de2-410d-bb02-cd3a95628238",
+    "organization_guid": "f0f0fefe-9d56-4830-8642-a738069a4cc3",
+    "service_plan_url": "/v2/service_plans/522fb1a6-5de2-410d-bb02-cd3a95628238",
+    "organization_url": "/v2/organizations/f0f0fefe-9d56-4830-8642-a738069a4cc3"
+  }
+}

--- a/test/v2/test_service_plan_visibilities.py
+++ b/test/v2/test_service_plan_visibilities.py
@@ -1,0 +1,96 @@
+import sys
+import unittest
+
+import cloudfoundry_client.main.main as main
+from abstract_test_case import AbstractTestCase
+from cloudfoundry_client.imported import OK, reduce
+from fake_requests import mock_response
+from imported import patch, CREATED, NO_CONTENT
+
+
+class TestServicePlanVisibilities(unittest.TestCase, AbstractTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.mock_client_class()
+
+    def setUp(self):
+        self.build_client()
+
+    def test_list(self):
+        self.client.get.return_value = mock_response(
+            '/v2/service_plan_visibilities?q=space_guid%3Aspace_guid',
+            OK,
+            None,
+            'v2', 'service_plan_visibilities', 'GET_response.json')
+        cpt = reduce(lambda increment, _: increment + 1,
+                     self.client.v2.service_plan_visibilities.list(space_guid='space_guid'), 0)
+        self.client.get.assert_called_with(self.client.get.return_value.url)
+        self.assertEqual(cpt, 1)
+
+    def test_get(self):
+        self.client.get.return_value = mock_response(
+            '/v2/service_plan_visibilities/guid',
+            OK,
+            None,
+            'v2', 'service_plan_visibilities', 'GET_{id}_response.json')
+        result = self.client.v2.service_plan_visibilities.get('guid')
+        self.client.get.assert_called_with(self.client.get.return_value.url)
+        self.assertIsNotNone(result)
+
+    def test_create(self):
+        self.client.post.return_value = mock_response(
+            '/v2/service_plan_visibilities',
+            CREATED,
+            None,
+            'v2', 'service_plan_visibilities', 'POST_response.json')
+        service_plan_visibilities = self.client.v2.service_plan_visibilities.create('service_plan_guid', 'organization_guid')
+        self.client.post.assert_called_with(self.client.post.return_value.url,
+                                            json=dict(service_plan_guid='service_plan_guid',
+                                                      organization_guid='organization_guid'))
+        self.assertIsNotNone(service_plan_visibilities)
+
+    def test_update(self):
+        self.client.put.return_value = mock_response(
+            '/v2/service_plan_visibilities/guid',
+            OK,
+            None,
+            'v2', 'service_plan_visibilities', 'PUT_{id}_response.json')
+        service_plan_visibilities = \
+            self.client.v2.service_plan_visibilities.update('guid',
+                                                            service_plan_guid='service_plan_guid',
+                                                            organization_guid='organization_guid')
+        self.client.put.assert_called_with(self.client.put.return_value.url,
+                                           json=dict(service_plan_guid='service_plan_guid',
+                                                     organization_guid='organization_guid'))
+        self.assertIsNotNone(service_plan_visibilities)
+
+    def test_delete(self):
+        self.client.delete.return_value = mock_response(
+            '/v2/service_plan_visibilities/guid',
+            NO_CONTENT,
+            None)
+        self.client.v2.service_plan_visibilities.remove('guid')
+        self.client.delete.assert_called_with(self.client.delete.return_value.url)
+
+    @patch.object(sys, 'argv', ['main', 'list_service_plan_visibilities'])
+    def test_main_list_service_plan_visibilities(self):
+        with patch('cloudfoundry_client.main.main.build_client_from_configuration',
+                   new=lambda: self.client):
+            self.client.get.return_value = mock_response('/v2/service_plan_visibilities',
+                                                         OK,
+                                                         None,
+                                                         'v2', 'service_plan_visibilities', 'GET_response.json')
+            main.main()
+            self.client.get.assert_called_with(self.client.get.return_value.url)
+
+    # looks funny "visibilitIE"
+    @patch.object(sys, 'argv', ['main', 'get_service_plan_visibilitie', 'a353104b-1290-418c-bc03-0e647afd0853'])
+    def test_main_get_service_plan_visibilities(self):
+        with patch('cloudfoundry_client.main.main.build_client_from_configuration',
+                   new=lambda: self.client):
+            self.client.get.return_value = mock_response('/v2/service_plan_visibilities/a353104b-1290-418c-bc03-0e647afd0853',
+                                                         OK,
+                                                         None,
+                                                         'v2', 'service_plan_visibilities', 'GET_{id}_response.json')
+            main.main()
+            self.client.get.assert_called_with(self.client.get.return_value.url)


### PR DESCRIPTION
I added ServicePlanVisibilities To the cf python client

NOTE: the CLI looks little funny because the name is not only the path without the trailing "s" (the "ie" gets "y") I am not sure if we should fix it.