### PR TITLE
Buildpacks v3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -191,6 +191,7 @@ Another example:
 Available managers on API V3 are:
 
 - ``apps``
+- ``buildpacks``
 - ``organizations``
 - ``service_instances``
 - ``spaces``

--- a/main/cloudfoundry_client/client.py
+++ b/main/cloudfoundry_client/client.py
@@ -7,7 +7,7 @@ from cloudfoundry_client.doppler.client import DopplerClient
 from cloudfoundry_client.errors import InvalidStatusCode
 from cloudfoundry_client.imported import UNAUTHORIZED
 from cloudfoundry_client.v2.apps import AppManager as AppManagerV2
-from cloudfoundry_client.v2.buildpacks import BuildpackManagerV2
+from cloudfoundry_client.v2.buildpacks import BuildpackManager as BuildpackManagerV2
 from cloudfoundry_client.v2.events import EventManager
 from cloudfoundry_client.v2.entities import EntityManager as EntityManagerV2
 from cloudfoundry_client.v2.jobs import JobManager

--- a/main/cloudfoundry_client/client.py
+++ b/main/cloudfoundry_client/client.py
@@ -7,7 +7,7 @@ from cloudfoundry_client.doppler.client import DopplerClient
 from cloudfoundry_client.errors import InvalidStatusCode
 from cloudfoundry_client.imported import UNAUTHORIZED
 from cloudfoundry_client.v2.apps import AppManager as AppManagerV2
-from cloudfoundry_client.v2.buildpacks import BuildpackManager
+from cloudfoundry_client.v2.buildpacks import BuildpackManagerV2
 from cloudfoundry_client.v2.events import EventManager
 from cloudfoundry_client.v2.entities import EntityManager as EntityManagerV2
 from cloudfoundry_client.v2.jobs import JobManager
@@ -20,6 +20,7 @@ from cloudfoundry_client.v2.service_keys import ServiceKeyManager
 from cloudfoundry_client.v2.service_plan_visibilities import ServicePlanVisibilityManager
 from cloudfoundry_client.v2.service_plans import ServicePlanManager
 from cloudfoundry_client.v3.apps import AppManager as AppManagerV3
+from cloudfoundry_client.v3.buildpacks import BuildpackManager as BuildpackManagerV3
 from cloudfoundry_client.v3.entities import EntityManager as EntityManagerV3
 from cloudfoundry_client.v3.tasks import TaskManager
 
@@ -37,7 +38,7 @@ class Info:
 class V2(object):
     def __init__(self, target_endpoint, credential_manager):
         self.apps = AppManagerV2(target_endpoint, credential_manager)
-        self.buildpacks = BuildpackManager(target_endpoint, credential_manager)
+        self.buildpacks = BuildpackManagerV2(target_endpoint, credential_manager)
         self.jobs = JobManager(target_endpoint, credential_manager)
         self.service_bindings = ServiceBindingManager(target_endpoint, credential_manager)
         self.service_brokers = ServiceBrokerManager(target_endpoint, credential_manager)
@@ -66,6 +67,7 @@ class V2(object):
 class V3(object):
     def __init__(self, target_endpoint, credential_manager):
         self.apps = AppManagerV3(target_endpoint, credential_manager)
+        self.buildpacks = BuildpackManagerV3(target_endpoint, credential_manager)
         self.spaces = EntityManagerV3(target_endpoint, credential_manager, '/v3/spaces')
         self.organizations = EntityManagerV3(target_endpoint, credential_manager, '/v3/organizations')
         self.service_instances = EntityManagerV3(target_endpoint, credential_manager, '/v3/service_instances')

--- a/main/cloudfoundry_client/main/command_domain.py
+++ b/main/cloudfoundry_client/main/command_domain.py
@@ -83,9 +83,9 @@ class CommandDomain(object):
         return re.match(r'[\d|a-z]{8}-[\d|a-z]{4}-[\d|a-z]{4}-[\d|a-z]{4}-[\d|a-z]{12}', s.lower()) is not None
 
     def id(self, entity):
-        if self.api_version == 2:
+        if self.api_version == 'v2':
             return entity['metadata']['guid']
-        elif self.api_version == 3:
+        elif self.api_version == 'v3':
             return entity['guid']
 
     def resolve_id(self, argument, get_by_name):
@@ -94,9 +94,9 @@ class CommandDomain(object):
         elif self.allow_retrieve_by_name:
             result = get_by_name(argument)
             if result is not None:
-                if self.api_version == 2:
+                if self.api_version == 'v2':
                     return result['metadata']['guid']
-                elif self.api_version == 3:
+                elif self.api_version == 'v3':
                     return result['guid']
             else:
                 raise InvalidStatusCode(NOT_FOUND, '%s with name %s' % (self.client_domain, argument))
@@ -104,9 +104,9 @@ class CommandDomain(object):
             raise ValueError('id: %s: does not allow search by name' % self.client_domain)
 
     def name(self, entity):
-        if self.api_version == 2:
+        if self.api_version == 'v2':
             return entity['entity'][self.name_property]
-        elif self.api_version == 3:
+        elif self.api_version == 'v3':
             return entity[self.name_property]
 
     def find_by_name(self, client, name):

--- a/main/cloudfoundry_client/main/main.py
+++ b/main/cloudfoundry_client/main/main.py
@@ -189,8 +189,9 @@ def main():
                       filter_list_parameters=['organization_guid', 'service_plan_guid'], name_property=None,
                       allow_retrieve_by_name=False, allow_creation=True, allow_deletion=True),
         CommandDomain(display_name='Buildpacks', entity_name='buildpack',
-                      filter_list_parameters=[], allow_retrieve_by_name=False,
-                      allow_creation=False, allow_deletion=False),
+                      api_version='v3',
+                      filter_list_parameters=[], allow_retrieve_by_name=True,
+                      allow_creation=True, allow_deletion=True),
         CommandDomain(display_name='Routes', entity_name='route', name_property='host', filter_list_parameters=[]),
         TaskCommandDomain()
     ]

--- a/main/cloudfoundry_client/main/main.py
+++ b/main/cloudfoundry_client/main/main.py
@@ -185,7 +185,6 @@ def main():
         CommandDomain(display_name='Service Broker', entity_name='service_broker',
                       filter_list_parameters=['name', 'space_guid'],
                       allow_retrieve_by_name=True, allow_creation=True, allow_deletion=True),
-        # exception, the name is not only 'strip trailing "s" from domain name'
         CommandDomain(display_name='Service Plan Visibilities', entity_name='service_plan_visibility',
                       filter_list_parameters=['organization_guid', 'service_plan_guid'], name_property=None,
                       allow_retrieve_by_name=False, allow_creation=True, allow_deletion=True),

--- a/main/cloudfoundry_client/v3/buildpacks.py
+++ b/main/cloudfoundry_client/v3/buildpacks.py
@@ -21,3 +21,7 @@ class BuildpackManager(EntityManager):
             }
         }
         return super(BuildpackManager, self)._create(data)
+
+    def remove(self, buildpack_guid):
+        super(BuildpackManager, self)._remove(buildpack_guid)
+

--- a/main/cloudfoundry_client/v3/buildpacks.py
+++ b/main/cloudfoundry_client/v3/buildpacks.py
@@ -25,3 +25,20 @@ class BuildpackManager(EntityManager):
     def remove(self, buildpack_guid):
         super(BuildpackManager, self)._remove(buildpack_guid)
 
+    # get and list are from main
+    def update(self, buildpack_guid, name, position=0, enabled=True,
+               locked=False, stack='', meta_labels={}, meta_annotations={}):
+        # XXX
+        data = {
+            'name': name,
+            'position': position,
+            'enabled': enabled,
+            'locked': locked,
+            'stack': stack,
+            'metadata': {
+                'labels': meta_labels,
+                'annotations': meta_annotations
+            }
+        }
+        return super(BuildpackManager, self)._update(buildpack_guid, data)
+

--- a/main/cloudfoundry_client/v3/buildpacks.py
+++ b/main/cloudfoundry_client/v3/buildpacks.py
@@ -7,8 +7,6 @@ class BuildpackManager(EntityManager):
 
     def create(self, name, position=0, enabled=True, locked=False, stack=None,
                meta_labels=None, meta_annotations=None):
-        # XXX typecheck? P3.7 => no problem, else it may be a little more code
-
         data = {
             'name': name,
             'position': position,
@@ -25,7 +23,6 @@ class BuildpackManager(EntityManager):
     def remove(self, buildpack_guid):
         super(BuildpackManager, self)._remove(buildpack_guid)
 
-    # get and list are from main
     def update(self, buildpack_guid, name, position=0, enabled=True,
                locked=False, stack=None, meta_labels=None, meta_annotations=None):
         data = {

--- a/main/cloudfoundry_client/v3/buildpacks.py
+++ b/main/cloudfoundry_client/v3/buildpacks.py
@@ -1,0 +1,23 @@
+from cloudfoundry_client.v3.entities import EntityManager
+
+
+class BuildpackManager(EntityManager):
+    def __init__(self, target_endpoint, client):
+        super(BuildpackManager, self).__init__(target_endpoint, client, '/v3/buildpacks')
+
+    def create(self, name, position=0, enabled=True, locked=False, stack=None,
+               meta_labels=None, meta_annotations=None):
+        # XXX typecheck? P3.7 => no problem, else it may be a little more code
+
+        data = {
+            'name': name,
+            'position': position,
+            'enabled': enabled,
+            'locked': locked,
+            'stack': stack,
+            'metadata': {
+                'labels': meta_labels,
+                'annotations': meta_annotations
+            }
+        }
+        return super(BuildpackManager, self)._create(data)

--- a/main/cloudfoundry_client/v3/buildpacks.py
+++ b/main/cloudfoundry_client/v3/buildpacks.py
@@ -41,3 +41,5 @@ class BuildpackManager(EntityManager):
         }
         return super(BuildpackManager, self)._update(buildpack_guid, data)
 
+    def upload(self, buildpack_guid, buildpack_zip):
+        return super(BuildpackManager, self)._upload_bits(buildpack_guid, buildpack_zip)

--- a/main/cloudfoundry_client/v3/buildpacks.py
+++ b/main/cloudfoundry_client/v3/buildpacks.py
@@ -27,8 +27,7 @@ class BuildpackManager(EntityManager):
 
     # get and list are from main
     def update(self, buildpack_guid, name, position=0, enabled=True,
-               locked=False, stack='', meta_labels={}, meta_annotations={}):
-        # XXX
+               locked=False, stack=None, meta_labels=None, meta_annotations=None):
         data = {
             'name': name,
             'position': position,

--- a/main/cloudfoundry_client/v3/entities.py
+++ b/main/cloudfoundry_client/v3/entities.py
@@ -91,6 +91,11 @@ class EntityManager(object):
         url = '%s%s' % (self.target_endpoint, self.entity_uri)
         return self._post(url, data=data)
 
+    def _upload_bits(self, resource_id, filename):
+        url = '%s%s/%s/upload' % (self.target_endpoint, self.entity_uri, resource_id)
+        files = {'bits': (filename, open(filename, 'rb'))}
+        return self._post(url, files=files)
+
     def _update(self, resource_id, data):
         url = '%s%s/%s' % (self.target_endpoint, self.entity_uri, resource_id)
         return self._patch(data, url)

--- a/main/cloudfoundry_client/v3/entities.py
+++ b/main/cloudfoundry_client/v3/entities.py
@@ -58,6 +58,11 @@ class EntityManager(object):
         _logger.debug('PUT - %s - %s', url, response.text)
         return self._read_response(response)
 
+    def _patch(self, data, url):
+        response = self.client.patch(url, json=data)
+        _logger.debug('PATCH - %s - %s', url, response.text)
+        return self._read_response(response)
+
     def _delete(self, url):
         response = self.client.delete(url)
         _logger.debug('DELETE - %s - %s', url, response.text)
@@ -88,7 +93,7 @@ class EntityManager(object):
 
     def _update(self, resource_id, data):
         url = '%s%s/%s' % (self.target_endpoint, self.entity_uri, resource_id)
-        return self._put(data, url)
+        return self._patch(data, url)
 
     def _remove(self, resource_id):
         url = '%s%s/%s' % (self.target_endpoint, self.entity_uri, resource_id)

--- a/main/cloudfoundry_client/v3/entities.py
+++ b/main/cloudfoundry_client/v3/entities.py
@@ -43,8 +43,8 @@ class EntityManager(object):
         self.entity_uri = entity_uri
         self.client = client
 
-    def _post(self, url, data=None):
-        response = self.client.post(url, json=data)
+    def _post(self, url, data=None, files=None):
+        response = self.client.post(url, json=data, files=files)
         _logger.debug('POST - %s - %s', url, response.text)
         return self._read_response(response)
 
@@ -89,7 +89,7 @@ class EntityManager(object):
 
     def _create(self, data):
         url = '%s%s' % (self.target_endpoint, self.entity_uri)
-        return self._post(url, data)
+        return self._post(url, data=data)
 
     def _update(self, resource_id, data):
         url = '%s%s/%s' % (self.target_endpoint, self.entity_uri, resource_id)

--- a/test/fixtures/v3/buildpacks/GET_response.json
+++ b/test/fixtures/v3/buildpacks/GET_response.json
@@ -1,0 +1,41 @@
+{
+  "pagination": {
+    "total_results": 3,
+    "total_pages": 2,
+    "first": {
+      "href": "https://api.example.org/v3/buildpacks?page=1&per_page=2"
+    },
+    "last": {
+      "href": "https://api.example.org/v3/buildpacks?page=2&per_page=2"
+    },
+    "next": null,
+    "previous": null
+  },
+  "resources": [
+    {
+      "guid": "fd35633f-5c5c-4e4e-a5a9-0722c970a9d2",
+      "created_at": "2016-03-18T23:26:46Z",
+      "updated_at": "2016-10-17T20:00:42Z",
+      "name": "my-buildpack",
+      "state": "AWAITING_UPLOAD",
+      "filename": null,
+      "stack": "my-stack",
+      "position": 1,
+      "enabled": true,
+      "locked": false,
+      "metadata": {
+        "labels": {},
+        "annotations": {}
+      },
+      "links": {
+        "self": {
+          "href": "https://api.example.org/v3/buildpacks/fd35633f-5c5c-4e4e-a5a9-0722c970a9d2"
+        },
+        "upload": {
+          "href": "https://api.example.org/v3/buildpacks/fd35633f-5c5c-4e4e-a5a9-0722c970a9d2/upload",
+          "method": "POST"
+        }
+      }
+    }
+  ]
+}

--- a/test/fixtures/v3/buildpacks/GET_{id}_response.json
+++ b/test/fixtures/v3/buildpacks/GET_{id}_response.json
@@ -1,0 +1,25 @@
+{
+  "guid": "fd35633f-5c5c-4e4e-a5a9-0722c970a9d2",
+  "created_at": "2016-03-18T23:26:46Z",
+  "updated_at": "2016-10-17T20:00:42Z",
+  "name": "ruby_buildpack",
+  "state": "AWAITING_UPLOAD",
+  "filename": null,
+  "stack": "windows64",
+  "position": 42,
+  "enabled": true,
+  "locked": false,
+  "metadata": {
+    "labels": { },
+    "annotations": { }
+  },
+  "links": {
+    "self": {
+      "href": "https://api.example.org/v3/buildpacks/fd35633f-5c5c-4e4e-a5a9-0722c970a9d2"
+    },
+    "upload": {
+        "href": "https://api.example.org/v3/buildpacks/fd35633f-5c5c-4e4e-a5a9-0722c970a9d2/upload",
+        "method": "POST"
+    }
+  }
+}

--- a/test/fixtures/v3/buildpacks/PATCH_{id}_response.json
+++ b/test/fixtures/v3/buildpacks/PATCH_{id}_response.json
@@ -1,0 +1,25 @@
+{
+  "guid": "fd35633f-5c5c-4e4e-a5a9-0722c970a9d2",
+  "created_at": "2016-03-18T23:26:46Z",
+  "updated_at": "2016-10-17T20:00:42Z",
+  "name": "ruby_buildpack",
+  "state": "AWAITING_UPLOAD",
+  "filename": null,
+  "stack": "windows64",
+  "position": 42,
+  "enabled": true,
+  "locked": false,
+  "metadata": {
+    "labels": { },
+    "annotations": { }
+  },
+  "links": {
+    "self": {
+      "href": "https://api.example.org/v3/buildpacks/fd35633f-5c5c-4e4e-a5a9-0722c970a9d2"
+    },
+    "upload": {
+        "href": "https://api.example.org/v3/buildpacks/fd35633f-5c5c-4e4e-a5a9-0722c970a9d2/upload",
+        "method": "POST"
+    }
+  }
+}

--- a/test/fixtures/v3/buildpacks/POST_response.json
+++ b/test/fixtures/v3/buildpacks/POST_response.json
@@ -1,0 +1,25 @@
+{
+  "guid": "fd35633f-5c5c-4e4e-a5a9-0722c970a9d2",
+  "created_at": "2016-03-18T23:26:46Z",
+  "updated_at": "2016-10-17T20:00:42Z",
+  "name": "ruby_buildpack",
+  "state": "AWAITING_UPLOAD",
+  "filename": null,
+  "stack": "windows64",
+  "position": 42,
+  "enabled": true,
+  "locked": false,
+  "metadata": {
+    "labels": { },
+    "annotations": { }
+  },
+  "links": {
+    "self": {
+      "href": "https://api.example.org/v3/buildpacks/fd35633f-5c5c-4e4e-a5a9-0722c970a9d2"
+    },
+    "upload": {
+        "href": "https://api.example.org/v3/buildpacks/fd35633f-5c5c-4e4e-a5a9-0722c970a9d2/upload",
+        "method": "POST"
+    }
+  }
+}

--- a/test/v2/test_buildpacks.py
+++ b/test/v2/test_buildpacks.py
@@ -1,7 +1,5 @@
-import sys
 import unittest
 
-import cloudfoundry_client.main.main as main
 from abstract_test_case import AbstractTestCase
 from cloudfoundry_client.imported import OK, reduce
 from fake_requests import mock_response
@@ -45,25 +43,3 @@ class TestBuildpacks(unittest.TestCase, AbstractTestCase):
         self.client.put.assert_called_with(self.client.put.return_value.url,
                                            json=dict(enabled=False))
         self.assertIsNotNone(result)
-
-    @patch.object(sys, 'argv', ['main', 'list_buildpacks'])
-    def test_main_list_buildpacks(self):
-        with patch('cloudfoundry_client.main.main.build_client_from_configuration',
-                        new=lambda: self.client):
-            self.client.get.return_value = mock_response('/v2/buildpacks',
-                                                         OK,
-                                                         None,
-                                                         'v2', 'buildpacks', 'GET_response.json')
-            main.main()
-            self.client.get.assert_called_with(self.client.get.return_value.url)
-
-    @patch.object(sys, 'argv', ['main', 'get_buildpack', '6e72c33b-dff0-4020-8603-bcd8a4eb05e4'])
-    def test_main_get_buildpack(self):
-        with patch('cloudfoundry_client.main.main.build_client_from_configuration',
-                        new=lambda: self.client):
-            self.client.get.return_value = mock_response('/v2/buildpacks/6e72c33b-dff0-4020-8603-bcd8a4eb05e4',
-                                                         OK,
-                                                         None,
-                                                         'v2', 'buildpacks', 'GET_{id}_response.json')
-            main.main()
-            self.client.get.assert_called_with(self.client.get.return_value.url)

--- a/test/v3/test_apps.py
+++ b/test/v3/test_apps.py
@@ -58,7 +58,7 @@ class TestApps(unittest.TestCase, AbstractTestCase):
 
         app = self.client.v3.apps.get('app_id').start()
         self.client.get.assert_called_with(self.client.get.return_value.url)
-        self.client.post.assert_called_with(self.client.post.return_value.url, json=None)
+        self.client.post.assert_called_with(self.client.post.return_value.url, files=None, json=None)
         self.assertEqual("my_app", app['name'])
         self.assertIsInstance(app, Entity)
 

--- a/test/v3/test_buildpacks.py
+++ b/test/v3/test_buildpacks.py
@@ -34,3 +34,12 @@ class TestBuildpacks(unittest.TestCase, AbstractTestCase):
         result = self.client.v3.buildpacks.get('buildpack_id')
         self.client.get.assert_called_with(self.client.get.return_value.url)
         self.assertIsNotNone(result)
+
+    def test_remove(self):
+        self.client.delete.return_value = mock_response(
+            '/v3/buildpacks/buildpack_id',
+            NO_CONTENT,
+            None)
+        self.client.v3.buildpacks.remove('buildpack_id')
+        self.client.delete.assert_called_with(self.client.delete.return_value.url)
+

--- a/test/v3/test_buildpacks.py
+++ b/test/v3/test_buildpacks.py
@@ -4,6 +4,7 @@ from abstract_test_case import AbstractTestCase
 from cloudfoundry_client.imported import OK, reduce
 from cloudfoundry_client.v3.entities import Entity
 from fake_requests import mock_response
+from imported import call, NO_CONTENT
 
 
 class TestBuildpacks(unittest.TestCase, AbstractTestCase):

--- a/test/v3/test_buildpacks.py
+++ b/test/v3/test_buildpacks.py
@@ -3,7 +3,7 @@ import unittest
 
 import cloudfoundry_client.main.main as main
 from abstract_test_case import AbstractTestCase
-from cloudfoundry_client.imported import OK, reduce
+from cloudfoundry_client.imported import OK
 from cloudfoundry_client.v3.entities import Entity
 from fake_requests import mock_response
 from imported import CREATED, patch
@@ -49,7 +49,6 @@ class TestBuildpacks(unittest.TestCase, AbstractTestCase):
                                                   enabled=True,
                                                   position=42,
                                                   stack='windows64')
-        print(result)
         self.client.patch.assert_called_with(self.client.patch.return_value.url,
                                              json={'locked': False,
                                                    'name': 'ruby_buildpack',

--- a/test/v3/test_buildpacks.py
+++ b/test/v3/test_buildpacks.py
@@ -57,8 +57,8 @@ class TestBuildpacks(unittest.TestCase, AbstractTestCase):
                                                    'position': 42,
                                                    'stack': 'windows64',
                                                    'metadata': {
-                                                       'labels': {},
-                                                       'annotations': {}
+                                                       'labels': None,
+                                                       'annotations': None
                                                    }
                                              })
         self.assertIsNotNone(result)

--- a/test/v3/test_buildpacks.py
+++ b/test/v3/test_buildpacks.py
@@ -1,9 +1,12 @@
+import sys
 import unittest
 
+import cloudfoundry_client.main.main as main
 from abstract_test_case import AbstractTestCase
 from cloudfoundry_client.imported import OK, reduce
 from cloudfoundry_client.v3.entities import Entity
 from fake_requests import mock_response
+from imported import CREATED, patch
 from imported import call, NO_CONTENT
 
 
@@ -36,6 +39,21 @@ class TestBuildpacks(unittest.TestCase, AbstractTestCase):
         self.client.get.assert_called_with(self.client.get.return_value.url)
         self.assertIsNotNone(result)
 
+    #def test_update(self):
+    #    self.client.patch.return_value = mock_response(
+    #        '/v3/buildpacks/buildpack_id',
+    #        patch,
+    #        None,
+    #        'v3', 'buildpacks', 'PATCH_{id}_response.json')
+    #    result = self.client.v3.buildpacks.update('buildpack_id', 'ruby_buildpack',
+    #                                              enabled=True,
+    #                                              position=42,
+    #                                              stack='windows64')
+    #    print(result)
+    #    self.client.patch.assert_called_with(self.client.patch.return_value.url,
+    #                                         json=dict(enabled=True))
+    #    self.assertIsNotNone(result)
+
     def test_remove(self):
         self.client.delete.return_value = mock_response(
             '/v3/buildpacks/buildpack_id',
@@ -44,3 +62,24 @@ class TestBuildpacks(unittest.TestCase, AbstractTestCase):
         self.client.v3.buildpacks.remove('buildpack_id')
         self.client.delete.assert_called_with(self.client.delete.return_value.url)
 
+    @patch.object(sys, 'argv', ['main', 'list_buildpacks'])
+    def test_main_list_buildpacks(self):
+        with patch('cloudfoundry_client.main.main.build_client_from_configuration',
+                   new=lambda: self.client):
+            self.client.get.return_value = mock_response('/v3/buildpacks',
+                                                         OK,
+                                                         None,
+                                                         'v3', 'buildpacks', 'GET_response.json')
+            main.main()
+            self.client.get.assert_called_with(self.client.get.return_value.url)
+
+    @patch.object(sys, 'argv', ['main', 'get_buildpack', '6e72c33b-dff0-4020-8603-bcd8a4eb05e4'])
+    def test_main_get_buildpack(self):
+        with patch('cloudfoundry_client.main.main.build_client_from_configuration',
+                        new=lambda: self.client):
+            self.client.get.return_value = mock_response('/v3/buildpacks/6e72c33b-dff0-4020-8603-bcd8a4eb05e4',
+                                                         OK,
+                                                         None,
+                                                         'v3', 'buildpacks', 'GET_{id}_response.json')
+            main.main()
+            self.client.get.assert_called_with(self.client.get.return_value.url)

--- a/test/v3/test_buildpacks.py
+++ b/test/v3/test_buildpacks.py
@@ -39,20 +39,29 @@ class TestBuildpacks(unittest.TestCase, AbstractTestCase):
         self.client.get.assert_called_with(self.client.get.return_value.url)
         self.assertIsNotNone(result)
 
-    #def test_update(self):
-    #    self.client.patch.return_value = mock_response(
-    #        '/v3/buildpacks/buildpack_id',
-    #        patch,
-    #        None,
-    #        'v3', 'buildpacks', 'PATCH_{id}_response.json')
-    #    result = self.client.v3.buildpacks.update('buildpack_id', 'ruby_buildpack',
-    #                                              enabled=True,
-    #                                              position=42,
-    #                                              stack='windows64')
-    #    print(result)
-    #    self.client.patch.assert_called_with(self.client.patch.return_value.url,
-    #                                         json=dict(enabled=True))
-    #    self.assertIsNotNone(result)
+    def test_update(self):
+        self.client.patch.return_value = mock_response(
+            '/v3/buildpacks/buildpack_id',
+            OK,
+            None,
+            'v3', 'buildpacks', 'PATCH_{id}_response.json')
+        result = self.client.v3.buildpacks.update('buildpack_id', 'ruby_buildpack',
+                                                  enabled=True,
+                                                  position=42,
+                                                  stack='windows64')
+        print(result)
+        self.client.patch.assert_called_with(self.client.patch.return_value.url,
+                                             json={'locked': False,
+                                                   'name': 'ruby_buildpack',
+                                                   'enabled': True,
+                                                   'position': 42,
+                                                   'stack': 'windows64',
+                                                   'metadata': {
+                                                       'labels': {},
+                                                       'annotations': {}
+                                                   }
+                                             })
+        self.assertIsNotNone(result)
 
     def test_remove(self):
         self.client.delete.return_value = mock_response(

--- a/test/v3/test_buildpacks.py
+++ b/test/v3/test_buildpacks.py
@@ -1,0 +1,36 @@
+import unittest
+
+from abstract_test_case import AbstractTestCase
+from cloudfoundry_client.imported import OK, reduce
+from cloudfoundry_client.v3.entities import Entity
+from fake_requests import mock_response
+
+
+class TestBuildpacks(unittest.TestCase, AbstractTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.mock_client_class()
+
+    def setUp(self):
+        self.build_client()
+
+    def test_list(self):
+        self.client.get.return_value = mock_response('/v3/buildpacks',
+                                                     OK,
+                                                     None,
+                                                     'v3', 'buildpacks', 'GET_response.json')
+        all_buildpacks = [buildpack for buildpack in self.client.v3.buildpacks.list()]
+        self.client.get.assert_called_with(self.client.get.return_value.url)
+        self.assertEqual(1, len(all_buildpacks))
+        self.assertEqual(all_buildpacks[0]['name'], "my-buildpack")
+        self.assertIsInstance(all_buildpacks[0], Entity)
+
+    def test_get(self):
+        self.client.get.return_value = mock_response(
+            '/v3/buildpacks/buildpack_id',
+            OK,
+            None,
+            'v3', 'buildpacks', 'GET_{id}_response.json')
+        result = self.client.v3.buildpacks.get('buildpack_id')
+        self.client.get.assert_called_with(self.client.get.return_value.url)
+        self.assertIsNotNone(result)

--- a/test/v3/test_tasks.py
+++ b/test/v3/test_tasks.py
@@ -46,8 +46,8 @@ class TestTasks(unittest.TestCase, AbstractTestCase):
             'v3', 'tasks', 'POST_response.json')
         task = self.client.v3.tasks.create('app_guid', command='rake db:migrate')
         self.client.post.assert_called_with(self.client.post.return_value.url,
-                                            json=dict(command='rake db:migrate')
-                                            )
+                                            files=None,
+                                            json=dict(command='rake db:migrate'))
         self.assertIsNotNone(task)
 
     def test_cancel(self):
@@ -57,7 +57,7 @@ class TestTasks(unittest.TestCase, AbstractTestCase):
             None,
             'v3', 'tasks', 'POST_{id}_actions_cancel_response.json')
         task = self.client.v3.tasks.cancel('task_guid')
-        self.client.post.assert_called_with(self.client.post.return_value.url, json=None)
+        self.client.post.assert_called_with(self.client.post.return_value.url, files=None, json=None)
         self.assertIsNotNone(task)
 
     @patch.object(sys, 'argv', ['main', 'list_tasks', '-names', 'task_name'])
@@ -81,6 +81,7 @@ class TestTasks(unittest.TestCase, AbstractTestCase):
                                                           'v3', 'tasks', 'POST_response.json')
             main.main()
             self.client.post.assert_called_with(self.client.post.return_value.url,
+                                                files=None,
                                                 json=dict(command='rake db:migrate', name='example'))
 
     @patch.object(sys, 'argv', ['main', 'cancel_task', 'task_id'])
@@ -92,4 +93,4 @@ class TestTasks(unittest.TestCase, AbstractTestCase):
                                                           None,
                                                           'v3', 'tasks', 'POST_{id}_actions_cancel_response.json')
             main.main()
-            self.client.post.assert_called_with(self.client.post.return_value.url, json=None)
+            self.client.post.assert_called_with(self.client.post.return_value.url, files=None, json=None)


### PR DESCRIPTION
Hi Ben,

I added the full buildpack functionality for API v3. This includes also the upload functionality of zip files.

* At the moment by default only V2 Entities were used, maybe we change this in the future (at the moment I had direct call "client.v3.buildpacks")
* In this scope I changed the responses of some calls. The reponse object includes in version3 no "entity" and "metadata" field
* With the APIv3 the "update" request will use "patch" not "put"
