### PR TITLE
Rlp gateway client

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -262,6 +262,21 @@ Logs can also be streamed using a websocket as follows:
         print(log)
 
 
+Logs can also be streamed directly from RLP gateway:
+
+.. code-block:: python
+
+    from cloudfoundry_client.client import CloudFoundryClient
+    target_endpoint = 'https://somewhere.org'
+    proxy = dict(http=os.environ.get('HTTP_PROXY', ''), https=os.environ.get('HTTPS_PROXY', ''))
+    rlp_client = CloudFoundryClient(target_endpoint, client_id='client_id', client_secret='client_secret', verify=False)
+    # init with client credentials
+    rlp_client.init_with_client_credentials()
+
+    async for log in rlp_client.rlpgateway.stream_logs('app-guid'):
+        print(log)
+
+
 Command Line Interface
 ----------------------
 

--- a/main/cloudfoundry_client/client.py
+++ b/main/cloudfoundry_client/client.py
@@ -1,19 +1,16 @@
 import logging
-from http import HTTPStatus
-from typing import Optional
 
 import requests
 from oauth2_client.credentials_manager import CredentialManager, ServiceInformation
-from requests import Response
 
 from cloudfoundry_client.doppler.client import DopplerClient
 from cloudfoundry_client.rlpgateway.client import RLPGatewayClient
-from cloudfoundry_client.networking.v1.external.policies import PolicyManager
 from cloudfoundry_client.errors import InvalidStatusCode
+from cloudfoundry_client.imported import UNAUTHORIZED
 from cloudfoundry_client.v2.apps import AppManager as AppManagerV2
-from cloudfoundry_client.v2.buildpacks import BuildpackManager as BuildpackManagerV2
-from cloudfoundry_client.v2.entities import EntityManager as EntityManagerV2
+from cloudfoundry_client.v2.buildpacks import BuildpackManager
 from cloudfoundry_client.v2.events import EventManager
+from cloudfoundry_client.v2.entities import EntityManager as EntityManagerV2
 from cloudfoundry_client.v2.jobs import JobManager
 from cloudfoundry_client.v2.resources import ResourceManager
 from cloudfoundry_client.v2.routes import RouteManager
@@ -24,20 +21,14 @@ from cloudfoundry_client.v2.service_keys import ServiceKeyManager
 from cloudfoundry_client.v2.service_plan_visibilities import ServicePlanVisibilityManager
 from cloudfoundry_client.v2.service_plans import ServicePlanManager
 from cloudfoundry_client.v3.apps import AppManager as AppManagerV3
-from cloudfoundry_client.v3.buildpacks import BuildpackManager as BuildpackManagerV3
-from cloudfoundry_client.v3.domains import DomainManager
 from cloudfoundry_client.v3.entities import EntityManager as EntityManagerV3
-from cloudfoundry_client.v3.feature_flags import FeatureFlagManager
-from cloudfoundry_client.v3.isolation_segments import IsolationSegmentManager
-from cloudfoundry_client.v3.organizations import OrganizationManager
-from cloudfoundry_client.v3.spaces import SpaceManager
 from cloudfoundry_client.v3.tasks import TaskManager
 
 _logger = logging.getLogger(__name__)
 
 
 class Info:
-    def __init__(self, api_version: str, authorization_endpoint: str, api_endpoint: str, doppler_endpoint: str):
+    def __init__(self, api_version, authorization_endpoint, api_endpoint, doppler_endpoint):
         self.api_version = api_version
         self.authorization_endpoint = authorization_endpoint
         self.api_endpoint = api_endpoint
@@ -46,15 +37,10 @@ class Info:
         self.rlp_gateway_endpoint = f'https://log-stream.{domain}'
 
 
-class NetworkingV1External(object):
-    def __init__(self, target_endpoint: str, credential_manager: 'CloudFoundryClient'):
-        self.policies = PolicyManager(target_endpoint, credential_manager)
-
-
 class V2(object):
-    def __init__(self, target_endpoint: str, credential_manager: 'CloudFoundryClient'):
+    def __init__(self, target_endpoint, credential_manager):
         self.apps = AppManagerV2(target_endpoint, credential_manager)
-        self.buildpacks = BuildpackManagerV2(target_endpoint, credential_manager)
+        self.buildpacks = BuildpackManager(target_endpoint, credential_manager)
         self.jobs = JobManager(target_endpoint, credential_manager)
         self.service_bindings = ServiceBindingManager(target_endpoint, credential_manager)
         self.service_brokers = ServiceBrokerManager(target_endpoint, credential_manager)
@@ -81,20 +67,16 @@ class V2(object):
 
 
 class V3(object):
-    def __init__(self, target_endpoint: str, credential_manager: 'CloudFoundryClient'):
+    def __init__(self, target_endpoint, credential_manager):
         self.apps = AppManagerV3(target_endpoint, credential_manager)
-        self.buildpacks = BuildpackManagerV3(target_endpoint, credential_manager)
-        self.domains = DomainManager(target_endpoint, credential_manager)
-        self.feature_flags = FeatureFlagManager(target_endpoint, credential_manager)
-        self.isolation_segments = IsolationSegmentManager(target_endpoint, credential_manager)
-        self.spaces = SpaceManager(target_endpoint, credential_manager)
-        self.organizations = OrganizationManager(target_endpoint, credential_manager)
+        self.spaces = EntityManagerV3(target_endpoint, credential_manager, '/v3/spaces')
+        self.organizations = EntityManagerV3(target_endpoint, credential_manager, '/v3/organizations')
         self.service_instances = EntityManagerV3(target_endpoint, credential_manager, '/v3/service_instances')
         self.tasks = TaskManager(target_endpoint, credential_manager)
 
 
 class CloudFoundryClient(CredentialManager):
-    def __init__(self, target_endpoint: str, client_id: str = 'cf', client_secret: str = '', **kwargs):
+    def __init__(self, target_endpoint, client_id='cf', client_secret='', **kwargs):
         """"
         :param target_endpoint :the target endpoint
         :param client_id: the client_id
@@ -115,15 +97,14 @@ class CloudFoundryClient(CredentialManager):
         verify = kwargs.get('verify', True)
         self.token_format = kwargs.get('token_format')
         self.login_hint = kwargs.get('login_hint')
-        target_endpoint_trimmed = target_endpoint.rstrip('/')
-        info = self._get_info(target_endpoint_trimmed, proxy, verify=verify)
+        info = self._get_info(target_endpoint, proxy, verify=verify)
         if not info.api_version.startswith('2.'):
             raise AssertionError('Only version 2 is supported for now. Found %s' % info.api_version)
         service_information = ServiceInformation(None, '%s/oauth/token' % info.authorization_endpoint,
                                                  client_id, client_secret, [], verify)
         super(CloudFoundryClient, self).__init__(service_information, proxies=proxy)
-        self.v2 = V2(target_endpoint_trimmed, self)
-        self.v3 = V3(target_endpoint_trimmed, self)
+        self.v2 = V2(target_endpoint, self)
+        self.v3 = V3(target_endpoint, self)
         self._doppler = DopplerClient(info.doppler_endpoint,
                                       self.proxies[
                                           'http' if info.doppler_endpoint.startswith('ws://') else 'https'],
@@ -135,11 +116,10 @@ class CloudFoundryClient(CredentialManager):
                                             self.service_information.verify,
                                             self,
                                             ) if info.rlp_gateway_endpoint is not None else None
-        self.networking_v1_external = NetworkingV1External(target_endpoint_trimmed, self)
         self.info = info
 
     @property
-    def doppler(self) -> DopplerClient:
+    def doppler(self):
         if self._doppler is None:
             raise NotImplementedError('No droppler endpoint for this instance')
         else:
@@ -155,7 +135,7 @@ class CloudFoundryClient(CredentialManager):
             return self._rlpgateway
 
     @staticmethod
-    def _get_info(target_endpoint: str, proxy: Optional[dict] = None, verify: bool = True) -> Info:
+    def _get_info(target_endpoint, proxy=None, verify=True):
         info_response = CloudFoundryClient._check_response(requests.get('%s/v2/info' % target_endpoint,
                                                                         proxies=proxy if proxy is not None else dict(
                                                                             http='', https=''),
@@ -167,20 +147,20 @@ class CloudFoundryClient(CredentialManager):
                     info.get('doppler_logging_endpoint'))
 
     @staticmethod
-    def _is_token_expired(response: Response) -> bool:
-        if response.status_code == HTTPStatus.UNAUTHORIZED.value:
+    def _is_token_expired(response):
+        if response.status_code == UNAUTHORIZED:
             try:
                 json_data = response.json()
                 result = json_data.get('code', 0) == 1000 and json_data.get('error_code', '') == 'CF-InvalidAuthToken'
                 _logger.info('_is_token_expired - %s' % str(result))
                 return result
-            except BaseException as _:
+            except Exception as _:
                 return False
         else:
             return False
 
     @staticmethod
-    def _token_request_headers(_) -> dict:
+    def _token_request_headers(_):
         return dict(Accept='application/json')
 
     def __getattr__(self, item):
@@ -190,7 +170,7 @@ class CloudFoundryClient(CredentialManager):
         else:
             raise AttributeError("type '%s' has no attribute '%s'" % (type(self).__name__, item))
 
-    def _grant_password_request(self, login: str, password: str) -> dict:
+    def _grant_password_request(self, login, password):
         request = super(CloudFoundryClient, self)._grant_password_request(login, password)
         if self.token_format is not None:
             request['token_format'] = self.token_format
@@ -198,34 +178,34 @@ class CloudFoundryClient(CredentialManager):
             request['login_hint'] = self.login_hint
         return request
 
-    def _grant_refresh_token_request(self, refresh_token: str) -> dict:
+    def _grant_refresh_token_request(self, refresh_token):
         request = super(CloudFoundryClient, self)._grant_refresh_token_request(refresh_token)
         if self.token_format is not None:
             request['token_format'] = self.token_format
         return request
 
-    def get(self, url: str, params: Optional[dict] = None, **kwargs) -> Response:
+    def get(self, url, params=None, **kwargs):
         response = super(CloudFoundryClient, self).get(url, params, **kwargs)
         return CloudFoundryClient._check_response(response)
 
-    def post(self, url: str, data=None, json=None, **kwargs) -> Response:
+    def post(self, url, data=None, json=None, **kwargs):
         response = super(CloudFoundryClient, self).post(url, data, json, **kwargs)
         return CloudFoundryClient._check_response(response)
 
-    def put(self, url: str, data=None, json=None, **kwargs) -> Response:
+    def put(self, url, data=None, json=None, **kwargs):
         response = super(CloudFoundryClient, self).put(url, data, json, **kwargs)
         return CloudFoundryClient._check_response(response)
 
-    def patch(self, url: str, data=None, json=None, **kwargs) -> Response:
+    def patch(self, url, data=None, json=None, **kwargs):
         response = super(CloudFoundryClient, self).patch(url, data, json, **kwargs)
         return CloudFoundryClient._check_response(response)
 
-    def delete(self, url: str, **kwargs) -> Response:
+    def delete(self, url, **kwargs):
         response = super(CloudFoundryClient, self).delete(url, **kwargs)
         return CloudFoundryClient._check_response(response)
 
     @staticmethod
-    def _check_response(response: Response) -> Response:
+    def _check_response(response):
         if int(response.status_code / 100) == 2:
             return response
         else:

--- a/main/cloudfoundry_client/rlpgateway/client.py
+++ b/main/cloudfoundry_client/rlpgateway/client.py
@@ -1,0 +1,39 @@
+import logging
+import aiohttp
+from cloudfoundry_client.imported import urlparse
+
+_logger = logging.getLogger(__name__)
+
+class RLPGatewayClient(object):
+    """
+    A client to read application logs directly from RLP gateway.
+
+    The client is initialized with client id and client secret,
+    and provides functionality for asynchronous HTTP requests to RLP gateway endpoint.
+    """
+    def __init__(self, rlp_gateway_endpoint, proxy, verify_ssl, credentials_manager):
+        self.proxy_host = None
+        self.proxy_port = None
+        self.rlp_gateway_endpoint = rlp_gateway_endpoint
+        self.verify_ssl = verify_ssl
+        self.credentials_manager = credentials_manager
+
+        if proxy is not None and len(proxy) > 0:
+            proxy_domain = urlparse(proxy).netloc
+            idx = proxy_domain.find(':')
+            if 0 < idx < len(proxy_domain) - 2:
+                self.proxy_host = proxy_domain[:idx]
+                self.proxy_port = int(proxy_domain[idx + 1:])
+
+    async def stream_logs(self, app_guid):
+        url = '%s/v2/read?log&source_id=%s' % (self.rlp_gateway_endpoint, app_guid)
+        async with aiohttp.ClientSession() as session:
+            response = await session.get(
+                    url=url,
+                    headers={"Authorization": self.credentials_manager._access_token},
+                )
+            if response.status == 204:
+                yield {}
+            else:
+                async for data in response.content.iter_any():
+                    yield data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp==3.6.2
 protobuf==3.6.1
 oauth2-client==1.2.0
 websocket-client==0.53.0


### PR DESCRIPTION
To fix issue #74, I have added a client for RLP Gateway, which has functionality to read application logs directly from gateway.

The official CF documentation can be found [here](https://github.com/cloudfoundry/loggregator/blob/master/docs/rlp_gateway.md).