### PR TITLE
More flexible RLP client

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -281,8 +281,9 @@ Logs can also be streamed using a websocket as follows:
         # read message infinitely (use break to exit... it will close the underlying websocket)
         print(log)
 
+..
 
-Logs can also be streamed directly from RLP gateway:
+Logs can also be streamed directly from RLP Gateway:
 
 .. code-block:: python
 
@@ -296,13 +297,16 @@ Logs can also be streamed directly from RLP gateway:
     rlp_client.init_with_client_credentials()
 
     async def get_logs_for_app(rlp_client, app_guid):
-        async for log in rlp_client.rlpgateway.stream_logs(app_guid):
+        async for log in rlp_client.rlpgateway.stream_logs(app_guid,
+                                                           params=['counter', 'gauge', 'counter.name=request_count'],
+                                                           headers={'User-Agent': 'test'})):
             print(log)
 
     loop = asyncio.get_event_loop()
     loop.create_task(get_logs_for_app(rlp_client, "app_guid"))
     loop.run_forever()
     loop.close()
+..
 
 Command Line Interface
 ----------------------

--- a/README.rst
+++ b/README.rst
@@ -299,7 +299,7 @@ Logs can also be streamed directly from RLP Gateway:
     async def get_logs_for_app(rlp_client, app_guid):
         async for log in rlp_client.rlpgateway.stream_logs(app_guid,
                                                            params=['counter', 'gauge', 'counter.name=request_count'],
-                                                           headers={'User-Agent': 'test'})):
+                                                           headers={'User-Agent': 'cf-python-client'})):
             print(log)
 
     loop = asyncio.get_event_loop()

--- a/README.rst
+++ b/README.rst
@@ -298,7 +298,7 @@ Logs can also be streamed directly from RLP Gateway:
 
     async def get_logs_for_app(rlp_client, app_guid):
         async for log in rlp_client.rlpgateway.stream_logs(app_guid,
-                                                           params=['counter', 'gauge', 'counter.name=request_count'],
+                                                           params={'counter': '', 'gauge': ''},
                                                            headers={'User-Agent': 'cf-python-client'})):
             print(log)
 

--- a/main/cloudfoundry_client/rlpgateway/client.py
+++ b/main/cloudfoundry_client/rlpgateway/client.py
@@ -36,10 +36,11 @@ class RLPGatewayClient(object):
         if "headers" in kwargs:
             headers.update(kwargs["headers"])
         if "params" in kwargs:
-            for param in kwargs["params"]:
-                url = f"{url}&{param}"
+            params = kwargs["params"]
+        else:
+            params = None
         async with aiohttp.ClientSession(headers=headers) as session:
-            async with session.get(url=url) as response:
+            async with session.get(url=url, params=params) as response:
                 if response.status == 204:
                     yield {}
                 else:

--- a/main/cloudfoundry_client/rlpgateway/client.py
+++ b/main/cloudfoundry_client/rlpgateway/client.py
@@ -23,18 +23,23 @@ class RLPGatewayClient(object):
 
         if proxy is not None and len(proxy) > 0:
             proxy_domain = urlparse(proxy).netloc
-            idx = proxy_domain.find(':')
+            idx = proxy_domain.find(":")
             if 0 < idx < len(proxy_domain) - 2:
                 self.proxy_host = proxy_domain[:idx]
-                self.proxy_port = int(proxy_domain[idx + 1:])
+                self.proxy_port = int(proxy_domain[idx + 1 :])
 
-    async def stream_logs(self, app_guid):
-        url = '%s/v2/read?log&source_id=%s' % (self.rlp_gateway_endpoint, app_guid)
-        async with aiohttp.ClientSession() as session:
-            async with session.get(
-                url=url,
-                headers={"Authorization": self.credentials_manager._access_token},
-            ) as response:
+    async def stream_logs(self, app_guid, **kwargs):
+        url = f"{self.rlp_gateway_endpoint}/v2/read?log&source_id={app_guid}"
+        headers = {
+            "Authorization": self.credentials_manager._access_token,
+        }
+        if "headers" in kwargs:
+            headers.update(kwargs["headers"])
+        if "params" in kwargs:
+            for param in kwargs["params"]:
+                url = f"{url}&{param}"
+        async with aiohttp.ClientSession(headers=headers) as session:
+            async with session.get(url=url) as response:
                 if response.status == 204:
                     yield {}
                 else:

--- a/main/cloudfoundry_client/rlpgateway/client.py
+++ b/main/cloudfoundry_client/rlpgateway/client.py
@@ -23,22 +23,19 @@ class RLPGatewayClient(object):
 
         if proxy is not None and len(proxy) > 0:
             proxy_domain = urlparse(proxy).netloc
-            idx = proxy_domain.find(':')
+            idx = proxy_domain.find(":")
             if 0 < idx < len(proxy_domain) - 2:
                 self.proxy_host = proxy_domain[:idx]
-                self.proxy_port = int(proxy_domain[idx + 1:])
+                self.proxy_port = int(proxy_domain[idx + 1 :])
 
     async def stream_logs(self, app_guid, **kwargs):
-        url = f"{self.rlp_gateway_endpoint}/v2/read?log&source_id={app_guid}"
-        headers = {
-            "Authorization": self.credentials_manager._access_token,
-        }
+        url = f"{self.rlp_gateway_endpoint}/v2/read"
+        headers = dict(Authorization=self.credentials_manager._access_token)
+        params = dict(log="", source_id=app_guid)
         if "headers" in kwargs:
             headers.update(kwargs["headers"])
         if "params" in kwargs:
-            params = kwargs["params"]
-        else:
-            params = None
+            params.update(kwargs["params"])
         async with aiohttp.ClientSession(headers=headers) as session:
             async with session.get(url=url, params=params) as response:
                 if response.status == 204:

--- a/main/cloudfoundry_client/rlpgateway/client.py
+++ b/main/cloudfoundry_client/rlpgateway/client.py
@@ -23,10 +23,10 @@ class RLPGatewayClient(object):
 
         if proxy is not None and len(proxy) > 0:
             proxy_domain = urlparse(proxy).netloc
-            idx = proxy_domain.find(":")
+            idx = proxy_domain.find(':')
             if 0 < idx < len(proxy_domain) - 2:
                 self.proxy_host = proxy_domain[:idx]
-                self.proxy_port = int(proxy_domain[idx + 1 :])
+                self.proxy_port = int(proxy_domain[idx + 1:])
 
     async def stream_logs(self, app_guid, **kwargs):
         url = f"{self.rlp_gateway_endpoint}/v2/read?log&source_id={app_guid}"


### PR DESCRIPTION
To be able to use [RLP Gateway](https://github.com/cloudfoundry/loggregator/blob/master/docs/rlp_gateway.md) functionality fully, I've added a possibility to modify requests from RLP client :
- custom headers
- custom params 
