### PR TITLE
Iterate RLP content

### DIFF
--- a/main/cloudfoundry_client/rlpgateway/client.py
+++ b/main/cloudfoundry_client/rlpgateway/client.py
@@ -41,5 +41,5 @@ class RLPGatewayClient(object):
                 if response.status == 204:
                     yield {}
                 else:
-                    async for data in response.content.iter_any():
+                    async for data in response.content:
                         yield data


### PR DESCRIPTION
I've noticed that in case of huge logs, `iter_any` does not iterate over chunks and does not recognise where the log message ends. As a result, the method would yield just part of the log message at a time. It makes it harder to consume logs.

Iterating through `response.content` ensure yielding one log message (separated by `\n)` at a time.