### PR TITLE
Stream reader

### DIFF
--- a/main/cloudfoundry_client/rlpgateway/client.py
+++ b/main/cloudfoundry_client/rlpgateway/client.py
@@ -41,5 +41,10 @@ class RLPGatewayClient(object):
                 if response.status == 204:
                     yield {}
                 else:
-                    async for data in response.content:
-                        yield data
+                    buffer = b""
+                    async for data in response.content.iter_chunked(1024):
+                        buffer += data
+                        if b"\n\n" in buffer and buffer.startswith(b"data:"):
+                            log_message = buffer.split(b"\n\n")[0]
+                            buffer = buffer.replace(log_message + b"\n\n", b"")
+                            yield log_message

--- a/main/cloudfoundry_client/rlpgateway/client.py
+++ b/main/cloudfoundry_client/rlpgateway/client.py
@@ -41,5 +41,5 @@ class RLPGatewayClient(object):
                 if response.status == 204:
                     yield {}
                 else:
-                    async for data in response.content.iter_any():
+                    async for data in response.content:
                         yield data


### PR DESCRIPTION
Hi,

As it turns out, aiohttp does not handle json streams well. 

Initially, we used `iter_any` to iterate through the logs, but the method implies `\r\n` delimiter (and RLP gateway messages are separated by `\n\n`), so some messages were skipped or merged into one. 

The current solution is iterating through messages separated by `\n`. That should work fine for json streams, however there is a size limitation for messages - 128kb. So, yet again, a few messages are being skipped. The issue is know - [rtfol/aiohttp-sse-client#11](https://github.com/rtfol/aiohttp-sse-client/issues/11), [aio-libs/aiohttp#4453](https://github.com/aio-libs/aiohttp/issues/4453), 

Of course, I would prefer aiohttp to extend the functionality - either add a `separator` argument or a flexible size limit. However, it can take time. 

In the meantime, I wrote a workaround, which allows to iterate through small chunks of data and separate messages by `\n\n`. Let me know what you think.

Thanks in advance!