### PR TITLE
Readme update - Include user_provided_service_instances in list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,6 +133,7 @@ So far the implemented managers that are available are:
 - ``service_plans``
 - ``service_plan_visibilities``
 - ``service_instances``
+- ``user_provided_service_instances``
 - ``service_keys``
 - ``service_bindings``
 - ``service_brokers``


### PR DESCRIPTION
I spent a few hours scracthing my head trying to work out why service_instances wasn't returning certain instances. I eventally discovered that user_provided_service_instances was a different endpoint, and that this was actually supported by this library, but not documented as an endpoint in the readme (Perhaps it's not fully ready yet, but it appears to be working for what I need). Here's a PR to add it into the readme.