### PR TITLE
Add v3 JobManager and job link to entities

### DIFF
--- a/main/cloudfoundry_client/client.py
+++ b/main/cloudfoundry_client/client.py
@@ -32,6 +32,7 @@ from cloudfoundry_client.v3.isolation_segments import IsolationSegmentManager
 from cloudfoundry_client.v3.organizations import OrganizationManager
 from cloudfoundry_client.v3.spaces import SpaceManager
 from cloudfoundry_client.v3.tasks import TaskManager
+from cloudfoundry_client.v3.jobs import JobManager as JobManagerV3
 
 _logger = logging.getLogger(__name__)
 
@@ -94,6 +95,7 @@ class V3(object):
         self.organizations = OrganizationManager(target_endpoint, credential_manager)
         self.service_instances = EntityManagerV3(target_endpoint, credential_manager, '/v3/service_instances')
         self.tasks = TaskManager(target_endpoint, credential_manager)
+        self.jobs = JobManagerV3(target_endpoint, credential_manager)
 
 
 class CloudFoundryClient(CredentialManager):

--- a/main/cloudfoundry_client/v3/entities.py
+++ b/main/cloudfoundry_client/v3/entities.py
@@ -181,6 +181,12 @@ class EntityManager(object):
 
     def _read_response(self, response: Response, entity_type: Optional[ENTITY_TYPE]) -> Union[JsonObject, Entity]:
         result = response.json(object_pairs_hook=JsonObject)
+        if 'Location' in response.headers:
+            result['links']['job'] = {
+                "href": response.headers['Location'],
+                "method": "GET",
+                }
+
         return self._entity(result, entity_type)
 
     @staticmethod

--- a/main/cloudfoundry_client/v3/jobs.py
+++ b/main/cloudfoundry_client/v3/jobs.py
@@ -1,0 +1,33 @@
+import types
+import polling2
+
+from cloudfoundry_client.v3.entities import EntityManager, Entity
+
+
+class JobTimeout(Exception):
+    pass
+
+
+class JobManager(EntityManager):
+    def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
+        super(JobManager, self).__init__(target_endpoint, client, "/v3/jobs")
+
+    def wait_for_job_completion(
+        self,
+        job_guid: str,
+        step: int = 1,
+        step_function: types.FunctionType = lambda step: min(step + step, 60),
+        poll_forever: bool = False,
+        timeout: int = 600,
+    ) -> Entity:
+        try:
+            return polling2.poll(
+                lambda: self.get(job_guid),
+                step=step,
+                step_function=step_function,
+                poll_forever=poll_forever,
+                timeout=timeout,
+                check_success=lambda job: job["state"] != "PROCESSING",
+            )
+        except polling2.TimeoutException as e:
+            raise JobTimeout(e)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ protobuf==3.6.1
 oauth2-client==1.2.1
 websocket-client==0.54.0
 PyYAML==5.3.1
+polling2==0.4.6

--- a/test/fixtures/v3/jobs/GET_{id}_complete_response.json
+++ b/test/fixtures/v3/jobs/GET_{id}_complete_response.json
@@ -1,0 +1,14 @@
+{
+    "guid": "b19ae525-cbd3-4155-b156-dc0c2a431b4c",
+    "created_at": "2016-10-19T20:25:04Z",
+    "updated_at": "2016-11-08T16:41:26Z",
+    "operation": "app.delete",
+    "state": "COMPLETE",
+    "links": {
+      "self": {
+        "href": "https://api.example.org/v3/jobs/b19ae525-cbd3-4155-b156-dc0c2a431b4c"
+      }
+    },
+    "errors": [],
+    "warnings": []
+  }

--- a/test/fixtures/v3/jobs/GET_{id}_failed_response.json
+++ b/test/fixtures/v3/jobs/GET_{id}_failed_response.json
@@ -1,0 +1,27 @@
+{
+  "guid": "b19ae525-cbd3-4155-b156-dc0c2a431b4c",
+  "created_at": "2016-10-19T20:25:04Z",
+  "updated_at": "2016-11-08T16:41:26Z",
+  "operation": "app.delete",
+  "state": "FAILED",
+  "links": {
+    "self": {
+      "href": "https://api.example.org/v3/jobs/b19ae525-cbd3-4155-b156-dc0c2a431b4c"
+    },
+    "app": {
+      "href": "https://api.example.org/v3/apps/7b34f1cf-7e73-428a-bb5a-8a17a8058396"
+    }
+  },
+  "errors": [
+    {
+      "code": 10008,
+      "title": "CF-UnprocessableEntity",
+      "detail": "something went wrong"
+    }
+  ],
+  "warnings": [
+    {
+      "detail": "warning! warning!"
+    }
+  ]
+}

--- a/test/fixtures/v3/jobs/GET_{id}_processing_response.json
+++ b/test/fixtures/v3/jobs/GET_{id}_processing_response.json
@@ -1,0 +1,14 @@
+{
+    "guid": "b19ae525-cbd3-4155-b156-dc0c2a431b4c",
+    "created_at": "2016-10-19T20:25:04Z",
+    "updated_at": "2016-11-08T16:41:26Z",
+    "operation": "app.delete",
+    "state": "PROCESSING",
+    "links": {
+      "self": {
+        "href": "https://api.example.org/v3/jobs/b19ae525-cbd3-4155-b156-dc0c2a431b4c"
+      }
+    },
+    "errors": [],
+    "warnings": []
+  }

--- a/test/v3/test_jobs.py
+++ b/test/v3/test_jobs.py
@@ -1,0 +1,115 @@
+import unittest
+from http import HTTPStatus
+from unittest.mock import patch, call
+from abstract_test_case import AbstractTestCase
+from cloudfoundry_client.v3.jobs import JobTimeout
+
+
+class TestJobs(unittest.TestCase, AbstractTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.mock_client_class()
+
+    def setUp(self):
+        self.build_client()
+
+    def test_get(self):
+        self.client.get.return_value = self.mock_response(
+            "/v3/jobs/job_id",
+            HTTPStatus.OK,
+            None,
+            "v3",
+            "jobs",
+            "GET_{id}_processing_response.json",
+        )
+        job = self.client.v3.jobs.get("job_id")
+        self.client.get.assert_called_with(self.client.get.return_value.url)
+        self.assertIsNotNone(job)
+
+    @patch("time.sleep", return_value=None)
+    def test_wait_for_job_completion(self, sleepmock):
+        self.client.get.side_effect = [
+            self.mock_response(
+                "/v3/jobs/job_id",
+                HTTPStatus.OK,
+                None,
+                "v3",
+                "jobs",
+                "GET_{id}_processing_response.json",
+            ),
+            self.mock_response(
+                "/v3/jobs/job_id",
+                HTTPStatus.OK,
+                None,
+                "v3",
+                "jobs",
+                "GET_{id}_processing_response.json",
+            ),
+            self.mock_response(
+                "/v3/jobs/job_id",
+                HTTPStatus.OK,
+                None,
+                "v3",
+                "jobs",
+                "GET_{id}_complete_response.json",
+            ),
+        ]
+
+        job = self.client.v3.jobs.wait_for_job_completion("job_id")
+
+        assert self.client.get.call_count == 3
+        self.assertIsNotNone(job)
+
+    def test_wait_for_job_completion_does_exponential_backoff(self):
+        self.client.get.side_effect = [
+            self.mock_response(
+                "/v3/jobs/job_id",
+                HTTPStatus.OK,
+                None,
+                "v3",
+                "jobs",
+                "GET_{id}_processing_response.json",
+            ),
+            self.mock_response(
+                "/v3/jobs/job_id",
+                HTTPStatus.OK,
+                None,
+                "v3",
+                "jobs",
+                "GET_{id}_processing_response.json",
+            ),
+            self.mock_response(
+                "/v3/jobs/job_id",
+                HTTPStatus.OK,
+                None,
+                "v3",
+                "jobs",
+                "GET_{id}_processing_response.json",
+            ),
+            self.mock_response(
+                "/v3/jobs/job_id",
+                HTTPStatus.OK,
+                None,
+                "v3",
+                "jobs",
+                "GET_{id}_complete_response.json",
+            ),
+        ]
+
+        with patch("time.sleep", return_value=None) as m:
+            self.client.v3.jobs.wait_for_job_completion("job_id")
+            m.assert_has_calls([call(1), call(2), call(4)])
+
+    @patch("time.sleep", return_value=None)
+    def test_wait_for_job_completion_has_timeout(self, sleepmock):
+        self.client.get.return_value = self.mock_response(
+            "/v3/jobs/job_id",
+            HTTPStatus.OK,
+            None,
+            "v3",
+            "jobs",
+            "GET_{id}_processing_response.json",
+        )
+
+        with self.assertRaises(JobTimeout):
+            self.client.v3.jobs.wait_for_job_completion("job_id", timeout=0.0001)


### PR DESCRIPTION
**A short explanation of the proposed change:**

We added a v3 JobManager and added a job link to entities in case the 'Location' header is present in the response of the API. The JobManager offers a polling mechanism using the python library 'polling2' to poll jobs until they were processed by the Cloud Controller.

**An explanation of the use cases your change solves:**

When uploading a buildpack using this lib (v3), so far there was no possibility to get back the job url, as the lib didn't extract it from the 'Location' header. Therefore, it was not possible to check whether the buildpack upload was successful or not. With our change the caller will get back the buildpack entitity including a link to the job, which then can be polled using the newly introduced polling functionality of the JobManager.

Calling the new functionality looks like this:
```
buildpack = cloudfoundry_client.v3.buildpacks.upload(buildpack_guid, binary_zip)

job = cloudfroundry_client.v3.jobs.wait_for_job_completion(buildpack.job()['guid'])
```

As long as a job url is returned in the 'Location' header from the API, the job link is added to the entity. So this works for all kinds of entities which are supported by this lib.

We would appreciate to get feedback on this. Please let us know what you think about the implementation and whether you have questions about it.