### PR TITLE
Fixes generated 'environment_variables' on V3 App entity

### DIFF
--- a/main/cloudfoundry_client/v3/apps.py
+++ b/main/cloudfoundry_client/v3/apps.py
@@ -1,15 +1,28 @@
+import functools
 from typing import TYPE_CHECKING
 
 from cloudfoundry_client.json_object import JsonObject
-from cloudfoundry_client.v3.entities import EntityManager
+from cloudfoundry_client.v3.entities import EntityManager, Entity
 
 if TYPE_CHECKING:
     from cloudfoundry_client.client import CloudFoundryClient
 
 
+class App(Entity):
+    def __init__(self, target_endpoint: str, client: "CloudFoundryClient", **kwargs):
+        super(App, self).__init__(target_endpoint, client, **kwargs)
+        # patch environment_variables method
+        environment_variables_link = self.get("links", {}).get('environment_variables', {}).get('href', None)
+        if environment_variables_link is not None:
+            other_manager = self._default_manager(client, target_endpoint)
+            new_method = functools.partial(other_manager._get, environment_variables_link)
+            new_method.__name__ = 'environment_variables'
+            setattr(self, 'environment_variables', new_method)
+
+
 class AppManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(AppManager, self).__init__(target_endpoint, client, "/v3/apps")
+        super(AppManager, self).__init__(target_endpoint, client, "/v3/apps", App)
 
     def remove(self, application_guid: str):
         super(AppManager, self)._remove(application_guid)

--- a/main/cloudfoundry_client/v3/domains.py
+++ b/main/cloudfoundry_client/v3/domains.py
@@ -7,8 +7,8 @@ if TYPE_CHECKING:
 
 
 class Domain(Entity):
-    def __init__(self, target_endpoint: str, entity_manager: "EntityManager", **kwargs):
-        super(Domain, self).__init__(target_endpoint, entity_manager, **kwargs)
+    def __init__(self, target_endpoint: str, client: "CloudFoundryClient", **kwargs):
+        super(Domain, self).__init__(target_endpoint, client, **kwargs)
         relationships = self["relationships"]
         if "organization" in relationships:
             self["relationships"]["organization"] = ToOneRelationship.from_json_object(relationships["organization"])

--- a/test/fixtures/v3/apps/GET_{id}_environment_variables_response.json
+++ b/test/fixtures/v3/apps/GET_{id}_environment_variables_response.json
@@ -1,0 +1,13 @@
+{
+  "var": {
+    "RAILS_ENV": "production"
+  },
+  "links": {
+    "self": {
+      "href": "https://api.example.org/v3/apps/[guid]/environment_variables"
+    },
+    "app": {
+      "href": "https://api.example.org/v3/apps/[guid]"
+    }
+  }
+}

--- a/test/v3/test_apps.py
+++ b/test/v3/test_apps.py
@@ -15,7 +15,8 @@ class TestApps(unittest.TestCase, AbstractTestCase):
         self.build_client()
 
     def test_list(self):
-        self.client.get.return_value = self.mock_response("/v3/apps", HTTPStatus.OK, None, "v3", "apps", "GET_response.json")
+        self.client.get.return_value = self.mock_response("/v3/apps", HTTPStatus.OK, None, "v3", "apps",
+                                                          "GET_response.json")
         all_applications = [application for application in self.client.v3.apps.list()]
         self.client.get.assert_called_with(self.client.get.return_value.url)
         self.assertEqual(2, len(all_applications))
@@ -34,7 +35,8 @@ class TestApps(unittest.TestCase, AbstractTestCase):
     def test_get_then_space(self):
         get_app = self.mock_response("/v3/apps/app_id", HTTPStatus.OK, None, "v3", "apps", "GET_{id}_response.json")
         get_space = self.mock_response(
-            "/v3/spaces/2f35885d-0c9d-4423-83ad-fd05066f8576", HTTPStatus.OK, None, "v3", "spaces", "GET_{id}_response.json"
+            "/v3/spaces/2f35885d-0c9d-4423-83ad-fd05066f8576", HTTPStatus.OK, None, "v3", "spaces",
+            "GET_{id}_response.json"
         )
         self.client.get.side_effect = [get_app, get_space]
         space = self.client.v3.apps.get("app_id").space()
@@ -56,6 +58,17 @@ class TestApps(unittest.TestCase, AbstractTestCase):
         self.client.post.assert_called_with(self.client.post.return_value.url, files=None, json=None)
         self.assertEqual("my_app", app["name"])
         self.assertIsInstance(app, Entity)
+
+    def test_get_then_environment_variables(self):
+        get_app = self.mock_response("/v3/apps/app_id", HTTPStatus.OK, None, "v3", "apps", "GET_{id}_response.json")
+        get_environment_variables = self.mock_response(
+            "/v3/apps/app_id/environment_variables", HTTPStatus.OK, None, "v3", "apps",
+            "GET_{id}_environment_variables_response.json"
+        )
+        self.client.get.side_effect = [get_app, get_environment_variables]
+        environment_variables = self.client.v3.apps.get("app_id").environment_variables()
+        self.assertIsInstance(environment_variables, dict)
+        self.assertEqual("production", environment_variables["var"]["RAILS_ENV"])
 
     def test_remove(self):
         self.client.delete.return_value = self.mock_response("/v3/apps/app_id", HTTPStatus.NO_CONTENT, None)


### PR DESCRIPTION
Despite name ends with `s`, `environment_variables` link is a single entity instead of a paginate resource

Close #115