### PR TITLE
Allow newer versions of protobuf package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp==3.7.4
-protobuf==3.6.1
+protobuf>=3.6.1
 oauth2-client==1.2.1
 websocket-client==0.54.0
 PyYAML==5.4.1


### PR DESCRIPTION
This is used to avoid dependencies conflicts in projects that depend on other packages that require newer protobuf.

Ran tests locally:
![image](https://user-images.githubusercontent.com/36376489/110103032-23014780-7dae-11eb-92cf-080427ae35c8.png)
