### PR TITLE
Add synchronous deletion for v3 service instances

### DIFF
--- a/main/cloudfoundry_client/client.py
+++ b/main/cloudfoundry_client/client.py
@@ -26,10 +26,10 @@ from cloudfoundry_client.v2.service_plans import ServicePlanManager
 from cloudfoundry_client.v3.apps import AppManager as AppManagerV3
 from cloudfoundry_client.v3.buildpacks import BuildpackManager as BuildpackManagerV3
 from cloudfoundry_client.v3.domains import DomainManager
-from cloudfoundry_client.v3.entities import EntityManager as EntityManagerV3
 from cloudfoundry_client.v3.feature_flags import FeatureFlagManager
 from cloudfoundry_client.v3.isolation_segments import IsolationSegmentManager
 from cloudfoundry_client.v3.organizations import OrganizationManager
+from cloudfoundry_client.v3.service_instances import ServiceInstanceManager as ServiceInstanceManagerV3
 from cloudfoundry_client.v3.spaces import SpaceManager
 from cloudfoundry_client.v3.tasks import TaskManager
 from cloudfoundry_client.v3.jobs import JobManager as JobManagerV3
@@ -96,7 +96,7 @@ class V3(object):
         self.isolation_segments = IsolationSegmentManager(target_endpoint, credential_manager)
         self.spaces = SpaceManager(target_endpoint, credential_manager)
         self.organizations = OrganizationManager(target_endpoint, credential_manager)
-        self.service_instances = EntityManagerV3(target_endpoint, credential_manager, "/v3/service_instances")
+        self.service_instances = ServiceInstanceManagerV3(target_endpoint, credential_manager)
         self.tasks = TaskManager(target_endpoint, credential_manager)
         self.jobs = JobManagerV3(target_endpoint, credential_manager)
 

--- a/main/cloudfoundry_client/v3/entities.py
+++ b/main/cloudfoundry_client/v3/entities.py
@@ -123,7 +123,7 @@ class EntityManager(object):
         response = self.client.delete(url)
         _logger.debug("DELETE - %s - %s", url, response.text)
         try:
-            return response.headers['Location']
+            return response.headers["Location"]
         except (AttributeError, KeyError):
             return None
 

--- a/main/cloudfoundry_client/v3/entities.py
+++ b/main/cloudfoundry_client/v3/entities.py
@@ -1,7 +1,7 @@
 import functools
 import logging
 from typing import Any, Generator, Optional, List, Tuple, Union, TypeVar, TYPE_CHECKING
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 from requests import Response
 
@@ -119,9 +119,13 @@ class EntityManager(object):
         _logger.debug("PATCH - %s - %s", url, response.text)
         return self._read_response(response, entity_type)
 
-    def _delete(self, url: str):
+    def _delete(self, url: str, entity_type: Optional[ENTITY_TYPE] = None) -> Optional[JsonObject]:
         response = self.client.delete(url)
         _logger.debug("DELETE - %s - %s", url, response.text)
+        try:
+            return response.headers['Location']
+        except (AttributeError, KeyError):
+            return None
 
     def _list(self, requested_path: str, entity_type: Optional[ENTITY_TYPE] = None, **kwargs) -> PaginateEntities:
         url_requested = EntityManager._get_url_filtered("%s%s" % (self.target_endpoint, requested_path), **kwargs)
@@ -158,9 +162,13 @@ class EntityManager(object):
         url = "%s%s/%s" % (self.target_endpoint, self.entity_uri, resource_id)
         return self._patch(url, data)
 
-    def _remove(self, resource_id: str):
+    def _remove(self, resource_id: str, asynchronous: bool = True):
         url = "%s%s/%s" % (self.target_endpoint, self.entity_uri, resource_id)
-        self._delete(url)
+        job_location = self._delete(url)
+        if not asynchronous and job_location is not None:
+            job_url = urlparse(job_location)
+            job_guid = job_url.path.rsplit("/", 1)[-1]
+            self.client.v3.jobs.wait_for_job_completion(job_guid)
 
     def __iter__(self) -> PaginateEntities:
         return self.list()

--- a/main/cloudfoundry_client/v3/entities.py
+++ b/main/cloudfoundry_client/v3/entities.py
@@ -119,7 +119,7 @@ class EntityManager(object):
         _logger.debug("PATCH - %s - %s", url, response.text)
         return self._read_response(response, entity_type)
 
-    def _delete(self, url: str, entity_type: Optional[ENTITY_TYPE] = None) -> Optional[JsonObject]:
+    def _delete(self, url: str) -> Optional[str]:
         response = self.client.delete(url)
         _logger.debug("DELETE - %s - %s", url, response.text)
         try:

--- a/main/cloudfoundry_client/v3/service_instances.py
+++ b/main/cloudfoundry_client/v3/service_instances.py
@@ -1,0 +1,14 @@
+from typing import TYPE_CHECKING
+
+from cloudfoundry_client.v3.entities import EntityManager
+
+if TYPE_CHECKING:
+    from cloudfoundry_client.client import CloudFoundryClient
+
+
+class ServiceInstanceManager(EntityManager):
+    def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
+        super(ServiceInstanceManager, self).__init__(target_endpoint, client, "/v3/service_instances")
+
+    def remove(self, guid: str, asynchronous: bool = True):
+        super(ServiceInstanceManager, self)._remove(guid, asynchronous)

--- a/test/abstract_test_case.py
+++ b/test/abstract_test_case.py
@@ -100,4 +100,4 @@ class AbstractTestCase(object):
                     headers=headers,
                 )
         else:
-            return MockResponse("%s%s" % (AbstractTestCase.TARGET_ENDPOINT, uri), status_code.value, "")
+            return MockResponse("%s%s" % (AbstractTestCase.TARGET_ENDPOINT, uri), status_code.value, "", headers)

--- a/test/v3/test_service_instances.py
+++ b/test/v3/test_service_instances.py
@@ -33,18 +33,26 @@ class TestServiceInstances(unittest.TestCase, AbstractTestCase):
         self.assertIsInstance(service_instance, Entity)
 
     def test_remove_user_provided_service_instance(self):
-        self.client.delete.return_value = self.mock_response("/v3/service_instances/service_instance_id", HTTPStatus.NO_CONTENT, None)
+        self.client.delete.return_value = self.mock_response(
+            "/v3/service_instances/service_instance_id", HTTPStatus.NO_CONTENT, None
+        )
         self.client.v3.service_instances.remove("service_instance_id")
         self.client.delete.assert_called_with(self.client.delete.return_value.url)
 
     def test_remove(self):
-        self.client.delete.return_value = self.mock_response("/v3/service_instances/service_instance_id", HTTPStatus.ACCEPTED, headers={"Location": "https://somewhere.org/v3/jobs/job_id"})
+        self.client.delete.return_value = self.mock_response(
+            "/v3/service_instances/service_instance_id",
+            HTTPStatus.ACCEPTED,
+            headers={"Location": "https://somewhere.org/v3/jobs/job_id"},
+        )
         self.client.v3.service_instances.remove("service_instance_id")
         self.client.delete.assert_called_with(self.client.delete.return_value.url)
 
     @patch("time.sleep", return_value=None)
     def test_remove_synchronous(self, sleepmock):
-        self.client.delete.return_value = self.mock_response("/v3/service_instances/service_instance_id", HTTPStatus.ACCEPTED, {"Location": "https://somewhere.org/v3/jobs/job_id"})
+        self.client.delete.return_value = self.mock_response(
+            "/v3/service_instances/service_instance_id", HTTPStatus.ACCEPTED, {"Location": "https://somewhere.org/v3/jobs/job_id"}
+        )
         self.client.get.side_effect = [
             self.mock_response(
                 "/v3/jobs/job_id",
@@ -63,6 +71,6 @@ class TestServiceInstances(unittest.TestCase, AbstractTestCase):
                 "GET_{id}_complete_response.json",
             ),
         ]
-        self.client.v3.service_instances.remove("service_instance_id",asynchronous=False)
+        self.client.v3.service_instances.remove("service_instance_id", asynchronous=False)
         self.client.delete.assert_called_with(self.client.delete.return_value.url)
         assert self.client.get.call_count == 2

--- a/test/v3/test_service_instances.py
+++ b/test/v3/test_service_instances.py
@@ -1,6 +1,6 @@
 import unittest
 from http import HTTPStatus
-
+from unittest.mock import patch
 from abstract_test_case import AbstractTestCase
 from cloudfoundry_client.v3.entities import Entity
 
@@ -31,3 +31,38 @@ class TestServiceInstances(unittest.TestCase, AbstractTestCase):
         self.client.get.assert_called_with(self.client.get.return_value.url)
         self.assertEqual("85ccdcad-d725-4109-bca4-fd6ba062b5c8", service_instance["guid"])
         self.assertIsInstance(service_instance, Entity)
+
+    def test_remove_user_provided_service_instance(self):
+        self.client.delete.return_value = self.mock_response("/v3/service_instances/service_instance_id", HTTPStatus.NO_CONTENT, None)
+        self.client.v3.service_instances.remove("service_instance_id")
+        self.client.delete.assert_called_with(self.client.delete.return_value.url)
+
+    def test_remove(self):
+        self.client.delete.return_value = self.mock_response("/v3/service_instances/service_instance_id", HTTPStatus.ACCEPTED, headers={"Location": "https://somewhere.org/v3/jobs/job_id"})
+        self.client.v3.service_instances.remove("service_instance_id")
+        self.client.delete.assert_called_with(self.client.delete.return_value.url)
+
+    @patch("time.sleep", return_value=None)
+    def test_remove_synchronous(self, sleepmock):
+        self.client.delete.return_value = self.mock_response("/v3/service_instances/service_instance_id", HTTPStatus.ACCEPTED, {"Location": "https://somewhere.org/v3/jobs/job_id"})
+        self.client.get.side_effect = [
+            self.mock_response(
+                "/v3/jobs/job_id",
+                HTTPStatus.OK,
+                None,
+                "v3",
+                "jobs",
+                "GET_{id}_processing_response.json",
+            ),
+            self.mock_response(
+                "/v3/jobs/job_id",
+                HTTPStatus.OK,
+                None,
+                "v3",
+                "jobs",
+                "GET_{id}_complete_response.json",
+            ),
+        ]
+        self.client.v3.service_instances.remove("service_instance_id",asynchronous=False)
+        self.client.delete.assert_called_with(self.client.delete.return_value.url)
+        assert self.client.get.call_count == 2


### PR DESCRIPTION
#### A short explanation of the proposed change:

I added an `asynchronous` parameter to provide the possibility to synchronously delete service instances:
```python
cloudfoundry_client.v3.service_instances.remove(service_instance_guid, asynchronous=False)
```

I added a V3 ServiceInstanceManager to add the parameter to the `remove` method.  I use the existing JobManager to poll the job until completed. All other deletion calls are not changed. I also added some tests.

I also fixed a small bug in the `MockResponse` constructor where the headers were not passed along.

#### An explanation of the use cases your change solves:

In a pipeline and in scripts, it is necessary to wait until an instance has been deleted until e.g. the next service instance is created. Since the v3 API only supports asynchronous deletion, the client has to implement waiting (this feature is also going to be available in the official [CF CLI](https://github.com/cloudfoundry/cli/issues/1354)).

It would be awesome, if you could provide some feedback. :)