### PR TITLE
Retrieve UAA endpoint from root rather than /info

### DIFF
--- a/main/cloudfoundry_client/client.py
+++ b/main/cloudfoundry_client/client.py
@@ -174,12 +174,6 @@ class CloudFoundryClient(CredentialManager):
 
     @staticmethod
     def _get_info(target_endpoint: str, proxy: Optional[dict] = None, verify: bool = True) -> Info:
-        info_response = CloudFoundryClient._check_response(
-            requests.get(
-                "%s/info" % target_endpoint, proxies=proxy if proxy is not None else dict(http="", https=""), verify=verify
-            )
-        )
-        info = info_response.json()
         root_response = CloudFoundryClient._check_response(
             requests.get("%s/" % target_endpoint, proxies=proxy if proxy is not None else dict(http="", https=""), verify=verify)
         )
@@ -190,7 +184,7 @@ class CloudFoundryClient(CredentialManager):
         log_stream = root_links.get("log_stream")
         return Info(
             root_links["cloud_controller_v2"]["meta"]["version"],
-            info["authorization_endpoint"],
+            root_links["login"]["href"],
             target_endpoint,
             logging.get("href") if logging is not None else None,
             log_stream.get("href") if log_stream is not None else None,

--- a/test/abstract_test_case.py
+++ b/test/abstract_test_case.py
@@ -46,16 +46,6 @@ class AbstractTestCase(object):
     def _mock_info_calls(requests, with_doppler: bool = True, with_log_streams: bool = True):
         requests.get.side_effect = [
             MockResponse(
-                "%s/v2/info" % AbstractTestCase.TARGET_ENDPOINT,
-                status_code=HTTPStatus.OK.value,
-                text=json.dumps(
-                    dict(
-                        authorization_endpoint=AbstractTestCase.AUTHORIZATION_ENDPOINT,
-                        token_endpoint=AbstractTestCase.TOKEN_ENDPOINT,
-                    )
-                ),
-            ),
-            MockResponse(
                 "%s/" % AbstractTestCase.TARGET_ENDPOINT,
                 status_code=HTTPStatus.OK.value,
                 text=json.dumps(
@@ -74,6 +64,7 @@ class AbstractTestCase(object):
                             "log_stream": dict(href=AbstractTestCase.LOG_STREAM_ENDPOINT) if with_log_streams else None,
                             "app_ssh": dict(href="ssh.nd-cfapi.itn.ftgroup:80"),
                             "uaa": dict(href="https://uaa.nd-cfapi.itn.ftgroup"),
+                            "login": dict(href=AbstractTestCase.AUTHORIZATION_ENDPOINT),
                             "network_policy_v0": dict(href="https://api.nd-cfapi.itn.ftgroup/networking/v0/external"),
                             "network_policy_v1": dict(href="https://api.nd-cfapi.itn.ftgroup/networking/v1/external"),
                         }


### PR DESCRIPTION
This PR changes where the `authorization_endpoint` is retrieved from. Changed from the deprecated endpoint `/info` to `/`.

This PR fixes the issue explained in #128