### PR TITLE
Return included entities

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -215,6 +215,23 @@ Another example:
     for task in client.v3.tasks.list(app_guids=['app-guid-1', 'app-guid-2']):
         task.cancel()
 
+When supported by the API, parent entities can be included in a single call. The included entities replace the links mentioned above.
+The following code snippet issues three requests to the API in order to get app, space and organization data:
+
+.. code-block:: python
+
+  app = client.v3.apps.get("app-guid")
+  print("App name: %s" % app["name])
+  space = app.space()
+  print("Space name: %s" % space["name])
+  org = space.organization()
+  print("Org name: %s" % org["name])
+
+By changing the first line only, a single request fetches all the data. The navigation from app to space and space to organization remains unchanged.
+
+.. code-block:: python
+
+  app = client.v3.apps.get("app-guid", include="space.organization")
 
 Available managers on API V3 are:
 
@@ -227,7 +244,10 @@ Available managers on API V3 are:
 - ``spaces``
 - ``tasks``
 
-The managers provide the same methods as the V2 managers.
+The managers provide the same methods as the V2 managers with the following differences:
+
+- ``get(**kwargs)``: supports keyword arguments that are passed on to the API, e.g. "include"
+
 
 Networking
 ----------

--- a/main/cloudfoundry_client/v3/apps.py
+++ b/main/cloudfoundry_client/v3/apps.py
@@ -1,5 +1,4 @@
-import functools
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from cloudfoundry_client.json_object import JsonObject
 from cloudfoundry_client.v3.entities import EntityManager, Entity
@@ -9,15 +8,11 @@ if TYPE_CHECKING:
 
 
 class App(Entity):
-    def __init__(self, target_endpoint: str, client: "CloudFoundryClient", **kwargs):
-        super(App, self).__init__(target_endpoint, client, **kwargs)
-        # patch environment_variables method
-        environment_variables_link = self.get("links", {}).get("environment_variables", {}).get("href", None)
-        if environment_variables_link is not None:
-            other_manager = self._default_manager(client, target_endpoint)
-            new_method = functools.partial(other_manager._get, environment_variables_link)
-            new_method.__name__ = "environment_variables"
-            setattr(self, "environment_variables", new_method)
+    @staticmethod
+    def _manager_method(link_name: str, link_method: str) -> Optional[str]:
+        if link_name == "environment_variables" and link_method == "get":
+            return "_get"  # instead of _paginate
+        return Entity._manager_method(link_name, link_method)
 
 
 class AppManager(EntityManager):

--- a/test/fixtures/v3/apps/GET_response_include_space.json
+++ b/test/fixtures/v3/apps/GET_response_include_space.json
@@ -1,0 +1,170 @@
+{
+  "pagination": {
+    "total_results": 3,
+    "total_pages": 2,
+    "first": {
+      "href": "http://somewhere.org/v3/apps?page=1&per_page=2"
+    },
+    "last": {
+      "href": "http://somewhere.org/v3/apps?page=2&per_page=2"
+    },
+    "next": null,
+    "previous": null
+  },
+  "resources": [
+    {
+      "guid": "1cb006ee-fb05-47e1-b541-c34179ddc446",
+      "name": "my_app",
+      "state": "STARTED",
+      "created_at": "2016-03-17T21:41:30Z",
+      "updated_at": "2016-03-18T11:32:30Z",
+      "lifecycle": {
+        "type": "buildpack",
+        "data": {
+          "buildpacks": [
+            "java_buildpack"
+          ],
+          "stack": "cflinuxfs2"
+        }
+      },
+      "relationships": {
+        "space": {
+          "data": {
+            "guid": "2f35885d-0c9d-4423-83ad-fd05066f8576"
+          }
+        }
+      },
+      "links": {
+        "self": {
+          "href": "http://somewhere.org/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446"
+        },
+        "space": {
+          "href": "http://somewhere.org/v3/spaces/2f35885d-0c9d-4423-83ad-fd05066f8576"
+        },
+        "processes": {
+          "href": "http://somewhere.org/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446/processes"
+        },
+        "route_mappings": {
+          "href": "http://somewhere.org/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446/route_mappings"
+        },
+        "packages": {
+          "href": "http://somewhere.org/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446/packages"
+        },
+        "environment_variables": {
+          "href": "http://somewhere.org/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446/environment_variables"
+        },
+        "current_droplet": {
+          "href": "http://somewhere.org/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446/droplets/current"
+        },
+        "droplets": {
+          "href": "http://somewhere.org/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446/droplets"
+        },
+        "tasks": {
+          "href": "http://somewhere.org/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446/tasks"
+        },
+        "start": {
+          "href": "http://somewhere.org/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446/actions/start",
+          "method": "POST"
+        },
+        "stop": {
+          "href": "http://somewhere.org/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446/actions/stop",
+          "method": "POST"
+        }
+      },
+      "metadata": {
+        "labels": {}
+      }
+    },
+    {
+      "guid": "02b4ec9b-94c7-4468-9c23-4e906191a0f8",
+      "name": "my_app2",
+      "state": "STOPPED",
+      "created_at": "1970-01-01T00:00:02Z",
+      "updated_at": "2016-06-08T16:41:26Z",
+      "lifecycle": {
+        "type": "buildpack",
+        "data": {
+          "buildpacks": [
+            "ruby_buildpack"
+          ],
+          "stack": "cflinuxfs2"
+        }
+      },
+      "relationships": {
+        "space": {
+          "data": {
+            "guid": "2f35885d-0c9d-4423-83ad-fd05066f8576"
+          }
+        }
+      },
+      "links": {
+        "self": {
+          "href": "http://somewhere.org/v3/apps/02b4ec9b-94c7-4468-9c23-4e906191a0f8"
+        },
+        "space": {
+          "href": "http://somewhere.org/v3/spaces/2f35885d-0c9d-4423-83ad-fd05066f8576"
+        },
+        "processes": {
+          "href": "http://somewhere.org/v3/apps/02b4ec9b-94c7-4468-9c23-4e906191a0f8/processes"
+        },
+        "route_mappings": {
+          "href": "http://somewhere.org/v3/apps/02b4ec9b-94c7-4468-9c23-4e906191a0f8/route_mappings"
+        },
+        "packages": {
+          "href": "http://somewhere.org/v3/apps/02b4ec9b-94c7-4468-9c23-4e906191a0f8/packages"
+        },
+        "environment_variables": {
+          "href": "http://somewhere.org/v3/apps/02b4ec9b-94c7-4468-9c23-4e906191a0f8/environment_variables"
+        },
+        "current_droplet": {
+          "href": "http://somewhere.org/v3/apps/02b4ec9b-94c7-4468-9c23-4e906191a0f8/droplets/current"
+        },
+        "droplets": {
+          "href": "http://somewhere.org/v3/apps/02b4ec9b-94c7-4468-9c23-4e906191a0f8/droplets"
+        },
+        "tasks": {
+          "href": "http://somewhere.org/v3/apps/02b4ec9b-94c7-4468-9c23-4e906191a0f8/tasks"
+        },
+        "start": {
+          "href": "http://somewhere.org/v3/apps/02b4ec9b-94c7-4468-9c23-4e906191a0f8/actions/start",
+          "method": "POST"
+        },
+        "stop": {
+          "href": "http://somewhere.org/v3/apps/02b4ec9b-94c7-4468-9c23-4e906191a0f8/actions/stop",
+          "method": "POST"
+        }
+      },
+      "metadata": {
+        "labels": {}
+      }
+    }
+  ],
+  "included": {
+    "spaces": [
+      {
+        "guid": "2f35885d-0c9d-4423-83ad-fd05066f8576",
+        "created_at": "2017-02-01T01:33:58Z",
+        "updated_at": "2017-02-01T01:33:58Z",
+        "name": "my_space",
+        "relationships": {
+          "organization": {
+            "data": {
+              "guid": "e00705b9-7b42-4561-ae97-2520399d2133"
+            }
+          }
+        },
+        "links": {
+          "self": {
+            "href": "http://somewhere.org/v3/spaces/2f35885d-0c9d-4423-83ad-fd05066f8576"
+          },
+          "organization": {
+            "href": "http://somewhere.org/v3/organizations/e00705b9-7b42-4561-ae97-2520399d2133"
+          }
+        },
+        "metadata": {
+          "labels": {}
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/v3/apps/GET_{id}_response_include_space_and_org.json
+++ b/test/fixtures/v3/apps/GET_{id}_response_include_space_and_org.json
@@ -1,0 +1,107 @@
+{
+  "guid": "app_id",
+  "name": "my_app",
+  "state": "STOPPED",
+  "created_at": "2016-03-17T21:41:30Z",
+  "updated_at": "2016-06-08T16:41:26Z",
+  "lifecycle": {
+    "type": "buildpack",
+    "data": {
+      "buildpacks": [
+        "java_buildpack"
+      ],
+      "stack": "cflinuxfs2"
+    }
+  },
+  "relationships": {
+    "space": {
+      "data": {
+        "guid": "2f35885d-0c9d-4423-83ad-fd05066f8576"
+      }
+    }
+  },
+  "links": {
+    "self": {
+      "href": "http://somewhere.org/v3/apps/app_id"
+    },
+    "space": {
+      "href": "http://somewhere.org/v3/spaces/2f35885d-0c9d-4423-83ad-fd05066f8576"
+    },
+    "processes": {
+      "href": "http://somewhere.org/v3/apps/app_id/processes"
+    },
+    "route_mappings": {
+      "href": "http://somewhere.org/v3/apps/app_id/route_mappings"
+    },
+    "packages": {
+      "href": "http://somewhere.org/v3/apps/app_id/packages"
+    },
+    "environment_variables": {
+      "href": "http://somewhere.org/v3/apps/app_id/environment_variables"
+    },
+    "current_droplet": {
+      "href": "http://somewhere.org/v3/apps/app_id/droplets/current"
+    },
+    "droplets": {
+      "href": "http://somewhere.org/v3/apps/app_id/droplets"
+    },
+    "tasks": {
+      "href": "http://somewhere.org/v3/apps/app_id/tasks"
+    },
+    "start": {
+      "href": "http://somewhere.org/v3/apps/app_id/actions/start",
+      "method": "POST"
+    },
+    "stop": {
+      "href": "http://somewhere.org/v3/apps/app_id/actions/stop",
+      "method": "POST"
+    }
+  },
+  "metadata": {
+    "labels": {}
+  },
+  "included": {
+    "spaces": [
+      {
+        "guid": "2f35885d-0c9d-4423-83ad-fd05066f8576",
+        "created_at": "2017-02-01T01:33:58Z",
+        "updated_at": "2017-02-01T01:33:58Z",
+        "name": "my_space",
+        "relationships": {
+          "organization": {
+            "data": {
+              "guid": "e00705b9-7b42-4561-ae97-2520399d2133"
+            }
+          }
+        },
+        "links": {
+          "self": {
+            "href": "http://somewhere.org/v3/spaces/2f35885d-0c9d-4423-83ad-fd05066f8576"
+          },
+          "organization": {
+            "href": "http://somewhere.org/v3/organizations/e00705b9-7b42-4561-ae97-2520399d2133"
+          }
+        },
+        "metadata": {
+          "labels": {}
+        }
+      }
+    ],
+    "organizations": [
+      {
+        "guid": "e00705b9-7b42-4561-ae97-2520399d2133",
+        "created_at": "2017-02-01T01:33:58Z",
+        "updated_at": "2017-02-01T01:33:58Z",
+        "name": "my_organization",
+        "links": {
+          "self": {
+            "href": "http://somewhere.org/v3/organizations/e00705b9-7b42-4561-ae97-2520399d2133"
+          }
+        },
+        "metadata": {
+          "labels": {}
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/v3/spaces/GET_response_include_org.json
+++ b/test/fixtures/v3/spaces/GET_response_include_org.json
@@ -1,0 +1,96 @@
+{
+  "pagination": {
+    "total_results": 2,
+    "total_pages": 1,
+    "first": {
+      "href": "http://somewhere.org/v3/spaces?page=1&per_page=50"
+    },
+    "last": {
+      "href": "http://somewhere.org/v3/spaces?page=1&per_page=50"
+    },
+    "next": null,
+    "previous": null
+  },
+  "resources": [
+    {
+      "guid": "885735b5-aea4-4cf5-8e44-961af0e41920",
+      "created_at": "2017-02-01T01:33:58Z",
+      "updated_at": "2017-02-01T01:33:58Z",
+      "name": "space1",
+      "relationships": {
+        "organization": {
+          "data": {
+            "guid": "e00705b9-7b42-4561-ae97-2520399d2133"
+          }
+        }
+      },
+      "links": {
+        "self": {
+          "href": "http://somewhere.org/v3/spaces/885735b5-aea4-4cf5-8e44-961af0e41920"
+        },
+        "organization": {
+          "href": "http://somewhere.org/v3/organizations/e00705b9-7b42-4561-ae97-2520399d2133"
+        }
+      },
+      "metadata": {
+        "labels": {}
+      }
+    },
+    {
+      "guid": "d4c91047-7b29-4fda-b7f9-04033e5c9c9f",
+      "created_at": "2017-02-02T00:14:30Z",
+      "updated_at": "2017-02-02T00:14:30Z",
+      "name": "space2",
+      "relationships": {
+        "organization": {
+          "data": {
+            "guid": "b4ce91bd-31df-4b7d-8fd4-21a6b533276b"
+          }
+        }
+      },
+      "links": {
+        "self": {
+          "href": "http://somewhere.org/v3/spaces/d4c91047-7b29-4fda-b7f9-04033e5c9c9f"
+        },
+        "organization": {
+          "href": "http://somewhere.org/v3/organizations/b4ce91bd-31df-4b7d-8fd4-21a6b533276b"
+        }
+      },
+      "metadata": {
+        "labels": {}
+      }
+    }
+  ],
+  "included": {
+    "organizations": [
+      {
+        "guid": "e00705b9-7b42-4561-ae97-2520399d2133",
+        "created_at": "2017-02-01T01:33:58Z",
+        "updated_at": "2017-02-01T01:33:58Z",
+        "name": "org1",
+        "links": {
+          "self": {
+            "href": "http://somewhere.org/v3/organizations/e00705b9-7b42-4561-ae97-2520399d2133"
+          }
+        },
+        "metadata": {
+          "labels": {}
+        }
+      },
+      {
+        "guid": "b4ce91bd-31df-4b7d-8fd4-21a6b533276b",
+        "created_at": "2017-02-02T00:14:30Z",
+        "updated_at": "2017-02-02T00:14:30Z",
+        "name": "org2",
+        "links": {
+          "self": {
+            "href": "http://somewhere.org/v3/organizations/b4ce91bd-31df-4b7d-8fd4-21a6b533276b"
+          }
+        },
+        "metadata": {
+          "labels": {}
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/v3/spaces/GET_{id}_response_include_org.json
+++ b/test/fixtures/v3/spaces/GET_{id}_response_include_org.json
@@ -1,0 +1,42 @@
+{
+  "guid": "885735b5-aea4-4cf5-8e44-961af0e41920",
+  "created_at": "2017-02-01T01:33:58Z",
+  "updated_at": "2017-02-01T01:33:58Z",
+  "name": "my-space",
+  "relationships": {
+    "organization": {
+      "data": {
+        "guid": "e00705b9-7b42-4561-ae97-2520399d2133"
+      }
+    }
+  },
+  "links": {
+    "self": {
+      "href": "http://somewhere.org/v3/spaces/885735b5-aea4-4cf5-8e44-961af0e41920"
+    },
+    "organization": {
+      "href": "http://somewhere.org/v3/organizations/e00705b9-7b42-4561-ae97-2520399d2133"
+    }
+  },
+  "metadata": {
+    "labels": {}
+  },
+  "included": {
+    "organizations": [
+      {
+        "guid": "e00705b9-7b42-4561-ae97-2520399d2133",
+        "created_at": "2017-02-01T01:33:58Z",
+        "updated_at": "2017-02-01T01:33:58Z",
+        "name": "my-organization",
+        "links": {
+          "self": {
+            "href": "http://somewhere.org/v3/organizations/e00705b9-7b42-4561-ae97-2520399d2133"
+          }
+        },
+        "metadata": {
+          "labels": {}
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Some api endpoints [1] support the inclusion of parent entities. From the currently supported V3 endpoints these are: Apps and Spaces

Added "kwargs" parameter to EntityManager.get; both "get" and "list" can be called with an "include" parameter.

EntityManager._get_url_filtered is now "_get_url_with_encoded_params" and is reused for encoding arbitrary "get" parameters.

EntityManager._read_response calls "_mixin_included_entities" to include the parent entities in the corresponding resource (they are returned in a separate "included" section by the api).

For included entities the Entity constructor overwrites the link method and simply returns the included entity. This is illustrated in the following examples:

### Example 1
The client issues two requests to the api:
- GET /v3/apps/app_id and
- GET /v3/spaces/space_id
```
app = client.v3.apps.get("app_id")
space = app.space()
```

### Example 2
The client issues a single request to the api:
- GET /v3/apps/app_id?include=space
```
app = client.v3.apps.get("app_id", include="space")
space = app.space()
```

EntityManager._get_entity_type can be overwritten to return a specific subclass of Entity based on the included name.

[1] https://v3-apidocs.cloudfoundry.org/version/3.100.0/index.html#resources-with-includes
