### PR TITLE
[Minor] Remove unnecessary default value from dict.get

### DIFF
--- a/integration/v2/test_applications.py
+++ b/integration/v2/test_applications.py
@@ -48,8 +48,8 @@ class TestApps(unittest.TestCase):
                     self.assertEqual(e.body.get("error_code"), "CF-AppStoppedStatsError")
                 env = client.v2.apps.get_env(application["metadata"]["guid"])
                 self.assertIsNotNone(env)
-                self.assertIsNotNone(env.get("application_env_json", None))
-                self.assertIsNotNone(env["application_env_json"].get("VCAP_APPLICATION", None))
+                self.assertIsNotNone(env.get("application_env_json"))
+                self.assertIsNotNone(env["application_env_json"].get("VCAP_APPLICATION"))
                 self.assertGreater(len(env["application_env_json"]["VCAP_APPLICATION"].get("application_uris", [])), 0)
                 _logger.debug("env = %s", json.dumps(env))
             cpt += 1

--- a/main/cloudfoundry_client/client.py
+++ b/main/cloudfoundry_client/client.py
@@ -205,7 +205,7 @@ class CloudFoundryClient(CredentialManager):
             try:
                 json_data = response.json()
                 invalid_token_error = "CF-InvalidAuthToken"
-                if json_data.get("errors", None) is not None:  # V3 error response
+                if json_data.get("errors") is not None:  # V3 error response
                     for error in json_data.get("errors"):
                         if error.get("code", 0) == 1000 and error.get("title", "") == invalid_token_error:
                             _logger.info("_is_token_v3_expired - true")
@@ -295,4 +295,4 @@ class CloudFoundryClient(CredentialManager):
                 body = response.json()
             except ValueError:
                 body = response.text
-            raise InvalidStatusCode(HTTPStatus(response.status_code), body, response.headers.get("x-vcap-request-id", None))
+            raise InvalidStatusCode(HTTPStatus(response.status_code), body, response.headers.get("x-vcap-request-id"))

--- a/main/cloudfoundry_client/operations/push/validation/manifest.py
+++ b/main/cloudfoundry_client/operations/push/validation/manifest.py
@@ -126,7 +126,7 @@ class ManifestReader(object):
 
     @staticmethod
     def _convert_environment(app_manifest: dict):
-        environment = app_manifest.get("env", None)
+        environment = app_manifest.get("env")
         if environment is not None:
             if type(environment) != dict:
                 raise AssertionError("'env' entry must be a dictionary")

--- a/main/cloudfoundry_client/v3/entities.py
+++ b/main/cloudfoundry_client/v3/entities.py
@@ -244,9 +244,9 @@ class EntityManager(object):
     def _include_resources(self, resource: JsonObject, result: JsonObject) -> None:
         for relationship_name, relationship in resource.get("relationships", {}).items():
             relationship_guid = (relationship.get("data") or {}).get("guid")
-            included_resources = result["included"].get(plural(relationship_name), None)
+            included_resources = result["included"].get(plural(relationship_name))
             if relationship_guid is not None and included_resources is not None:
-                included_resource = next((r for r in included_resources if relationship_guid == r.get("guid", None)), None)
+                included_resource = next((r for r in included_resources if relationship_guid == r.get("guid")), None)
                 if included_resource is not None:
                     self._include_resources(included_resource, result)
                     included = resource.setdefault("_included", {})


### PR DESCRIPTION
As @andy-paine pointed out in his [commit](https://github.com/cloudfoundry-community/cf-python-client/commit/923c2450772f63d699ed6fced34e04921afbc9c9), the default value returned from `dict.get` is already `None`. So I've removed it everywhere.