### PR TITLE
Add organization quota manager + methods

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -238,10 +238,16 @@ Available managers on API V3 are:
 - ``apps``
 - ``buildpacks``
 - ``domains``
-- ``feature-flags``
+- ``feature_flags``
+- ``isolation_segments``
+- ``jobs``
 - ``organizations``
 - ``organization_quotas``
+- ``processes``
+- ``service_brokers``
 - ``service_instances``
+- ``service_offerings``
+- ``service_plans``
 - ``spaces``
 - ``tasks``
 

--- a/README.rst
+++ b/README.rst
@@ -240,6 +240,7 @@ Available managers on API V3 are:
 - ``domains``
 - ``feature-flags``
 - ``organizations``
+- ``organization_quotas``
 - ``service_instances``
 - ``spaces``
 - ``tasks``

--- a/main/cloudfoundry_client/client.py
+++ b/main/cloudfoundry_client/client.py
@@ -29,6 +29,7 @@ from cloudfoundry_client.v3.buildpacks import BuildpackManager
 from cloudfoundry_client.v3.domains import DomainManager
 from cloudfoundry_client.v3.feature_flags import FeatureFlagManager
 from cloudfoundry_client.v3.isolation_segments import IsolationSegmentManager
+from cloudfoundry_client.v3.organization_quotas import OrganizationQuotaManager
 from cloudfoundry_client.v3.processes import ProcessManager
 from cloudfoundry_client.v3.organizations import OrganizationManager
 from cloudfoundry_client.v3.service_brokers import ServiceBrokerManager
@@ -101,6 +102,7 @@ class V3(object):
         self.isolation_segments = IsolationSegmentManager(target_endpoint, credential_manager)
         self.jobs = JobManager(target_endpoint, credential_manager)
         self.organizations = OrganizationManager(target_endpoint, credential_manager)
+        self.organization_quotas = OrganizationQuotaManager(target_endpoint, credential_manager)
         self.processes = ProcessManager(target_endpoint, credential_manager)
         self.service_brokers = ServiceBrokerManager(target_endpoint, credential_manager)
         self.service_instances = ServiceInstanceManager(target_endpoint, credential_manager)

--- a/main/cloudfoundry_client/main/main.py
+++ b/main/cloudfoundry_client/main/main.py
@@ -181,6 +181,15 @@ def main():
             allow_deletion=True,
         ),
         CommandDomain(
+            display_name="OrganizationQuotas",
+            entity_name="organization_quota",
+            api_version="v3",
+            filter_list_parameters=["names", "guids", "organization_guids"],
+            allow_retrieve_by_name=True,
+            allow_creation=True,
+            allow_deletion=True,
+        ),
+        CommandDomain(
             display_name="Spaces",
             entity_name="space",
             filter_list_parameters=["organization_guid"],

--- a/main/cloudfoundry_client/v3/organization_quotas.py
+++ b/main/cloudfoundry_client/v3/organization_quotas.py
@@ -1,0 +1,93 @@
+from typing import List, Optional, TYPE_CHECKING
+from dataclasses import dataclass, asdict
+
+from cloudfoundry_client.v3.entities import Entity, EntityManager, ToManyRelationship
+
+if TYPE_CHECKING:
+    from cloudfoundry_client.client import CloudFoundryClient
+
+
+@dataclass
+class AppsQuota:
+    total_memory_in_mb: int
+    per_process_memory_in_mb: int
+    total_instances: int
+    per_app_tasks: int
+
+
+@dataclass
+class ServicesQuota:
+    paid_services_allowed: bool
+    total_service_instances: int
+    total_service_keys: int
+
+
+@dataclass
+class RoutesQuota:
+    total_routes: int
+    total_reserved_ports: int
+
+
+@dataclass
+class DomainsQuota:
+    total_domains: int
+
+
+class OrganizationQuotaManager(EntityManager):
+    def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
+        super().__init__(target_endpoint, client, "/v3/organization_quotas")
+
+    def remove(self, guid: str):
+        super()._remove(guid)
+
+    def create(
+        self,
+        name: str,
+        apps_quota: Optional[AppsQuota] = None,
+        services_quota: Optional[ServicesQuota] = None,
+        routes_quota: Optional[RoutesQuota] = None,
+        domains_quota: Optional[DomainsQuota] = None,
+        assigned_organizations: Optional[List[str]] = None,
+    ) -> Entity:
+        data = self._asdict(name, apps_quota, services_quota, routes_quota, domains_quota, assigned_organizations)
+        return super()._create(data)
+
+    def update(
+        self,
+        guid: str,
+        name: str,
+        apps_quota: Optional[AppsQuota] = None,
+        services_quota: Optional[ServicesQuota] = None,
+        routes_quota: Optional[RoutesQuota] = None,
+        domains_quota: Optional[DomainsQuota] = None,
+    ) -> Entity:
+        data = self._asdict(name, apps_quota, services_quota, routes_quota, domains_quota)
+        return super()._update(guid, data)
+
+    def apply_to_organizations(self, guid: str, organization_guids: List[str]) -> ToManyRelationship:
+        data = ToManyRelationship(*organization_guids)
+        return ToManyRelationship.from_json_object(
+            super()._post("%s%s/%s/relationships/organizations" % (self.target_endpoint, self.entity_uri, guid), data=data)
+        )
+
+    def _asdict(
+        self,
+        name: str,
+        apps_quota: Optional[AppsQuota] = None,
+        services_quota: Optional[ServicesQuota] = None,
+        routes_quota: Optional[RoutesQuota] = None,
+        domains_quota: Optional[DomainsQuota] = None,
+        assigned_organizations: Optional[List[str]] = None,
+    ):
+        data = {"name": name}
+        if apps_quota:
+            data["apps"] = asdict(apps_quota)
+        if services_quota:
+            data["services"] = asdict(services_quota)
+        if routes_quota:
+            data["routes"] = asdict(routes_quota)
+        if domains_quota:
+            data["domains"] = asdict(domains_quota)
+        if assigned_organizations:
+            data["relationships"] = {"organizations": assigned_organizations}
+        return data

--- a/test/fixtures/v3/organization_quotas/GET_response.json
+++ b/test/fixtures/v3/organization_quotas/GET_response.json
@@ -1,0 +1,88 @@
+{
+  "pagination": {
+    "total_results": 2,
+    "total_pages": 1,
+    "first": {
+      "href": "https://api.example.org/v3/organization_quotas?page=1&per_page=50"
+    },
+    "last": {
+      "href": "https://api.example.org/v3/organization_quotas?page=1&per_page=50"
+    },
+    "next": null,
+    "previous": null
+  },
+  "resources": [
+    {
+      "guid": "quota-1-guid",
+      "created_at": "2016-05-04T17:00:41Z",
+      "updated_at": "2016-05-04T17:00:41Z",
+      "name": "don-quixote",
+      "apps": {
+        "total_memory_in_mb": 5120,
+        "per_process_memory_in_mb": 1024,
+        "total_instances": 10,
+        "per_app_tasks": 5
+      },
+      "services": {
+        "paid_services_allowed": true,
+        "total_service_instances": 10,
+        "total_service_keys": 20
+      },
+      "routes": {
+        "total_routes": 8,
+        "total_reserved_ports": 4
+      },
+      "domains": {
+        "total_domains": 7
+      },
+      "relationships": {
+        "organizations": {
+          "data": [
+            {
+              "guid": "9b370018-c38e-44c9-86d6-155c76801104"
+            }
+          ]
+        }
+      },
+      "links": {
+        "self": {
+          "href": "https://api.example.org/v3/organization_quotas/quota-1-guid"
+        }
+      }
+    },
+    {
+      "guid": "quota-2-guid",
+      "created_at": "2017-05-04T17:00:41Z",
+      "updated_at": "2017-05-04T17:00:41Z",
+      "name": "sancho-panza",
+      "apps": {
+        "total_memory_in_mb": 2048,
+        "per_process_memory_in_mb": 1024,
+        "total_instances": 5,
+        "per_app_tasks": 2
+      },
+      "services": {
+        "paid_services_allowed": true,
+        "total_service_instances": 10,
+        "total_service_keys": 20
+      },
+      "routes": {
+        "total_routes": 8,
+        "total_reserved_ports": 4
+      },
+      "domains": {
+        "total_domains": 7
+      },
+      "relationships": {
+        "organizations": {
+          "data": []
+        }
+      },
+      "links": {
+        "self": {
+          "href": "https://api.example.org/v3/organization_quotas/quota-2-guid"
+        }
+      }
+    }
+  ]
+}

--- a/test/fixtures/v3/organization_quotas/GET_{id}_response.json
+++ b/test/fixtures/v3/organization_quotas/GET_{id}_response.json
@@ -1,0 +1,38 @@
+{
+  "guid": "quota-guid",
+  "created_at": "2016-05-04T17:00:41Z",
+  "updated_at": "2016-05-04T17:00:41Z",
+  "name": "don-quixote",
+  "apps": {
+    "total_memory_in_mb": 5120,
+    "per_process_memory_in_mb": 1024,
+    "total_instances": 10,
+    "per_app_tasks": 5
+  },
+  "services": {
+    "paid_services_allowed": true,
+    "total_service_instances": 10,
+    "total_service_keys": 20
+  },
+  "routes": {
+    "total_routes": 8,
+    "total_reserved_ports": 4
+  },
+  "domains": {
+    "total_domains": 7
+  },
+  "relationships": {
+    "organizations": {
+      "data": [
+        {
+          "guid": "9b370018-c38e-44c9-86d6-155c76801104"
+        }
+      ]
+    }
+  },
+  "links": {
+    "self": {
+      "href": "https://api.example.org/v3/organization_quotas/quota-guid"
+    }
+  }
+}

--- a/test/fixtures/v3/organization_quotas/PATCH_{id}_response.json
+++ b/test/fixtures/v3/organization_quotas/PATCH_{id}_response.json
@@ -1,0 +1,38 @@
+{
+  "guid": "quota-guid",
+  "created_at": "2016-05-04T17:00:41Z",
+  "updated_at": "2016-05-04T17:00:41Z",
+  "name": "don-quixote",
+  "apps": {
+    "total_memory_in_mb": 5120,
+    "per_process_memory_in_mb": 1024,
+    "total_instances": 10,
+    "per_app_tasks": 5
+  },
+  "services": {
+    "paid_services_allowed": true,
+    "total_service_instances": 10,
+    "total_service_keys": 20
+  },
+  "routes": {
+    "total_routes": 8,
+    "total_reserved_ports": 4
+  },
+  "domains": {
+    "total_domains": 7
+  },
+  "relationships": {
+    "organizations": {
+      "data": [
+        {
+          "guid": "9b370018-c38e-44c9-86d6-155c76801104"
+        }
+      ]
+    }
+  },
+  "links": {
+    "self": {
+      "href": "https://api.example.org/v3/organization_quotas/quota-guid"
+    }
+  }
+}

--- a/test/fixtures/v3/organization_quotas/POST_response.json
+++ b/test/fixtures/v3/organization_quotas/POST_response.json
@@ -1,0 +1,38 @@
+{
+  "guid": "quota-guid",
+  "created_at": "2016-05-04T17:00:41Z",
+  "updated_at": "2016-05-04T17:00:41Z",
+  "name": "don-quixote",
+  "apps": {
+    "total_memory_in_mb": 5120,
+    "per_process_memory_in_mb": 1024,
+    "total_instances": 10,
+    "per_app_tasks": 5
+  },
+  "services": {
+    "paid_services_allowed": true,
+    "total_service_instances": 10,
+    "total_service_keys": 20
+  },
+  "routes": {
+    "total_routes": 8,
+    "total_reserved_ports": 4
+  },
+  "domains": {
+    "total_domains": 7
+  },
+  "relationships": {
+    "organizations": {
+      "data": [
+        {
+          "guid": "9b370018-c38e-44c9-86d6-155c76801104"
+        }
+      ]
+    }
+  },
+  "links": {
+    "self": {
+      "href": "https://api.example.org/v3/organization_quotas/quota-guid"
+    }
+  }
+}

--- a/test/fixtures/v3/organization_quotas/POST_{id}_organizations_response.json
+++ b/test/fixtures/v3/organization_quotas/POST_{id}_organizations_response.json
@@ -1,0 +1,18 @@
+{
+    "data": [
+        {
+            "guid": "org-guid1"
+        },
+        {
+            "guid": "org-guid2"
+        },
+        {
+            "guid": "previous-org-guid"
+        }
+    ],
+    "links": {
+        "self": {
+            "href": "https://api.example.org/v3/organization_quotas/quota-guid/relationships/organizations"
+        }
+    }
+}

--- a/test/v3/test_organization_quotas.py
+++ b/test/v3/test_organization_quotas.py
@@ -1,0 +1,136 @@
+import sys
+import unittest
+from http import HTTPStatus
+from unittest.mock import patch
+
+import cloudfoundry_client.main.main as main
+from abstract_test_case import AbstractTestCase
+from cloudfoundry_client.v3.entities import Entity, ToManyRelationship
+from cloudfoundry_client.v3.organization_quotas import AppsQuota, DomainsQuota, RoutesQuota, ServicesQuota
+
+
+class TestOrganizationQuotas(unittest.TestCase, AbstractTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.mock_client_class()
+
+    def setUp(self):
+        self.build_client()
+
+    def test_list(self):
+        self.client.get.return_value = self.mock_response(
+            "/v3/organization_quotas", HTTPStatus.OK, None, "v3", "organization_quotas", "GET_response.json"
+        )
+        all_quotas = [quota for quota in self.client.v3.organization_quotas.list()]
+        self.client.get.assert_called_with(self.client.get.return_value.url)
+        self.assertEqual(2, len(all_quotas))
+        self.assertEqual(all_quotas[0]["name"], "don-quixote")
+        self.assertIsInstance(all_quotas[0], Entity)
+
+    def test_get(self):
+        self.client.get.return_value = self.mock_response(
+            "/v3/organization_quotas/quota-guid", HTTPStatus.OK, None, "v3", "organization_quotas", "GET_{id}_response.json"
+        )
+        quota = self.client.v3.organization_quotas.get("quota-guid")
+        self.client.get.assert_called_with(self.client.get.return_value.url)
+        self.assertEqual("don-quixote", quota["name"])
+        self.assertIsInstance(quota, Entity)
+
+    def test_update(self):
+        self.client.patch.return_value = self.mock_response(
+            "/v3/organization_quotas/quota_id", HTTPStatus.OK, None, "v3", "organization_quotas", "PATCH_{id}_response.json"
+        )
+        result = self.client.v3.organization_quotas.update(
+            "quota_id",
+            "don-quixote",
+            apps_quota=AppsQuota(total_memory_in_mb=5120, per_process_memory_in_mb=1024, total_instances=10, per_app_tasks=5),
+            services_quota=ServicesQuota(paid_services_allowed=True, total_service_instances=10, total_service_keys=20),
+            routes_quota=RoutesQuota(total_routes=8, total_reserved_ports=4),
+            domains_quota=DomainsQuota(total_domains=7),
+        )
+        self.client.patch.assert_called_with(
+            self.client.patch.return_value.url,
+            json={
+                "name": "don-quixote",
+                "apps": {"total_memory_in_mb": 5120, "per_process_memory_in_mb": 1024, "total_instances": 10, "per_app_tasks": 5},
+                "services": {"paid_services_allowed": True, "total_service_instances": 10, "total_service_keys": 20},
+                "routes": {"total_routes": 8, "total_reserved_ports": 4},
+                "domains": {"total_domains": 7},
+            },
+        )
+        self.assertIsNotNone(result)
+
+    def test_create(self):
+        self.client.post.return_value = self.mock_response(
+            "/v3/organization_quotas", HTTPStatus.OK, None, "v3", "organization_quotas", "POST_response.json"
+        )
+        result = self.client.v3.organization_quotas.create(
+            "don-quixote",
+            apps_quota=AppsQuota(total_memory_in_mb=5120, per_process_memory_in_mb=1024, total_instances=10, per_app_tasks=5),
+            services_quota=ServicesQuota(paid_services_allowed=True, total_service_instances=10, total_service_keys=20),
+            routes_quota=RoutesQuota(total_routes=8, total_reserved_ports=4),
+            domains_quota=DomainsQuota(total_domains=7),
+            assigned_organizations=["assigned-org"],
+        )
+        self.client.post.assert_called_with(
+            self.client.post.return_value.url,
+            files=None,
+            json={
+                "name": "don-quixote",
+                "apps": {"total_memory_in_mb": 5120, "per_process_memory_in_mb": 1024, "total_instances": 10, "per_app_tasks": 5},
+                "services": {"paid_services_allowed": True, "total_service_instances": 10, "total_service_keys": 20},
+                "routes": {"total_routes": 8, "total_reserved_ports": 4},
+                "domains": {"total_domains": 7},
+                "relationships": {"organizations": ["assigned-org"]},
+            },
+        )
+        self.assertIsNotNone(result)
+
+    def test_apply_to_organizations(self):
+        self.client.post.return_value = self.mock_response(
+            "/v3/organization_quotas/quota_id/relationships/organizations",
+            HTTPStatus.OK,
+            None,
+            "v3",
+            "organization_quotas",
+            "POST_{id}_organizations_response.json",
+        )
+        result = self.client.v3.organization_quotas.apply_to_organizations(
+            "quota_id",
+            organization_guids=["org-guid1", "org-guid2"],
+        )
+        self.client.post.assert_called_with(
+            self.client.post.return_value.url, files=None, json={"data": [{"guid": "org-guid1"}, {"guid": "org-guid2"}]}
+        )
+        self.assertIsInstance(result, ToManyRelationship)
+        # Endpoint adds to existing list of orgs so 1 existing + 2 new
+        self.assertEqual(3, len(result.guids))
+        self.assertIsNotNone(result["links"])
+
+    def test_remove(self):
+        self.client.delete.return_value = self.mock_response("/v3/organization_quotas/quota_id", HTTPStatus.NO_CONTENT, None)
+        self.client.v3.organization_quotas.remove("quota_id")
+        self.client.delete.assert_called_with(self.client.delete.return_value.url)
+
+    @patch.object(sys, "argv", ["main", "list_organization_quotas"])
+    def test_main_list_organization_quotas(self):
+        with patch("cloudfoundry_client.main.main.build_client_from_configuration", new=lambda: self.client):
+            self.client.get.return_value = self.mock_response(
+                "/v3/organization_quotas", HTTPStatus.OK, None, "v3", "organization_quotas", "GET_response.json"
+            )
+            main.main()
+            self.client.get.assert_called_with(self.client.get.return_value.url)
+
+    @patch.object(sys, "argv", ["main", "get_organization_quota", "1d3bf0ec-5806-43c4-b64e-8364dba1086a"])
+    def test_main_get_organization_quotas(self):
+        with patch("cloudfoundry_client.main.main.build_client_from_configuration", new=lambda: self.client):
+            self.client.get.return_value = self.mock_response(
+                "/v3/organization_quotas/1d3bf0ec-5806-43c4-b64e-8364dba1086a",
+                HTTPStatus.OK,
+                None,
+                "v3",
+                "organization_quotas",
+                "GET_{id}_response.json",
+            )
+            main.main()
+            self.client.get.assert_called_with(self.client.get.return_value.url)


### PR DESCRIPTION
This mostly behaves like a normal Entity manager with some additional requirements around updating quota amounts and organizations separately. Using @dataclasses allows for an easy way to take structured arguments for POSTing to CC and should add some helpful type hinting.

JSON examples are copied directly from the V3 API docs

+1 commit to fix README will list of available managers