### PR TITLE
Change check_success state to FAILED or COMPLETE

### DIFF
--- a/main/cloudfoundry_client/v3/jobs.py
+++ b/main/cloudfoundry_client/v3/jobs.py
@@ -32,7 +32,7 @@ class JobManager(EntityManager):
                 step_function=step_function,
                 poll_forever=poll_forever,
                 timeout=timeout,
-                check_success=lambda job: job["state"] != "PROCESSING",
+                check_success=lambda job: job["state"] == "FAILED" or job["state"] == "COMPLETE",
             )
         except polling2.TimeoutException as e:
             raise JobTimeout(e)


### PR DESCRIPTION
- Due to the PPOLLING state, the only state of waiting is not any more
  only PROCESSING, but PROCESSING and POLLING. So we want to check
  if state is FAILED or COMPELETE to be sure it finished.