### PR TITLE
Update functionality has been added to the V3 ServiceInstanceManager.…

### DIFF
--- a/main/cloudfoundry_client/v3/service_instances.py
+++ b/main/cloudfoundry_client/v3/service_instances.py
@@ -38,5 +38,37 @@ class ServiceInstanceManager(EntityManager):
             data["metadata"] = metadata
         return super(ServiceInstanceManager, self)._create(data)
 
+    def update(
+            self,
+            instance_guid: str,
+            name: Optional[str] = None,
+            parameters: Optional[dict] = None,
+            service_plan: Optional[str] = None,
+            maintenance_info: Optional[str] = None,
+            meta_labels: Optional[dict] = None,
+            meta_annotations: Optional[dict] = None,
+            tags: Optional[List[str]] = None
+    ) -> Entity:
+        data = {}
+        if name:
+            data["name"] = name
+        if parameters:
+            data["parameters"] = parameters
+        if service_plan:
+            data["relationships"] = {
+                "service_plan": ToOneRelationship(service_plan)}
+        if maintenance_info:
+            data["maintenance_info"] = {"version": maintenance_info}
+        if tags:
+            data["tags"] = tags
+        if meta_labels or meta_annotations:
+            metadata = dict()
+            if meta_labels:
+                metadata["labels"] = meta_labels
+            if meta_annotations:
+                metadata["annotations"] = meta_annotations
+            data["metadata"] = metadata
+        return super(ServiceInstanceManager, self)._update(instance_guid, data)
+
     def remove(self, guid: str, asynchronous: bool = True):
         super(ServiceInstanceManager, self)._remove(guid, asynchronous)

--- a/test/v3/test_service_instances.py
+++ b/test/v3/test_service_instances.py
@@ -44,6 +44,41 @@ class TestServiceInstances(unittest.TestCase, AbstractTestCase):
         self.assertIsNotNone(result)
         self.assertIsInstance(result, Entity)
 
+    def test_update(self):
+        self.client.patch.return_value = self.mock_response(
+            "/v3/service_instances/instance-guid-123",
+            HTTPStatus.ACCEPTED,
+            headers={"Location": "https://somewhere.org/v3/jobs/job_id"},
+        )
+        result = self.client.v3.service_instances.update(
+            instance_guid="instance-guid-123",
+            name="space-name",
+            parameters={"foo": "bar"},
+            service_plan="custom_service_plan",
+            maintenance_info="1.2.3",
+            meta_labels={"foo": "bar"},
+            meta_annotations={"foo": "bar"},
+            tags=["mytag", "myothertag"],
+        )
+
+        self.client.patch.assert_called_with(
+            self.client.patch.return_value.url,
+            json={
+                "name": "space-name",
+                "parameters": {"foo": "bar"},
+                "relationships": {
+                    "service_plan": {
+                        "data": {"guid": "custom_service_plan"}},
+                },
+                "maintenance_info": {"version": "1.2.3"},
+                "tags": ["mytag", "myothertag"],
+                "metadata": {'labels': {'foo': 'bar'},
+                             'annotations': {'foo': 'bar'}}
+            },
+        )
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, Entity)
+
     def test_list(self):
         self.client.get.return_value = self.mock_response(
             "/v3/service_instances", HTTPStatus.OK, None, "v3", "service_instances", "GET_response.json"


### PR DESCRIPTION
Hello,

I tried to use update the service instance via V3 API. I realized that the update function is missing in V3 SDK.

I'd like to add the update function to the V3 ServiceInstanceManager class.