### PR TITLE
Restart endpoint added to V3 AppManager

### DIFF
--- a/main/cloudfoundry_client/v3/apps.py
+++ b/main/cloudfoundry_client/v3/apps.py
@@ -19,6 +19,11 @@ class AppManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
         super(AppManager, self).__init__(target_endpoint, client, "/v3/apps", App)
 
+    def restart(self, application_guid: str):
+        return super(AppManager, self)._post("%s%s/%s/actions/restart" % (self.target_endpoint,
+                                                                          self.entity_uri,
+                                                                          application_guid))
+
     def remove(self, application_guid: str):
         super(AppManager, self)._remove(application_guid)
 

--- a/test/v3/test_apps.py
+++ b/test/v3/test_apps.py
@@ -73,6 +73,16 @@ class TestApps(unittest.TestCase, AbstractTestCase):
         self.assertIsInstance(environment_variables, dict)
         self.assertEqual("production", environment_variables["var"]["RAILS_ENV"])
 
+    def test_restart(self):
+        self.client.post.return_value = self.mock_response(
+            "/v3/apps/app_id/actions/restart", HTTPStatus.OK, None, "v3", "apps",
+            "GET_{id}_response.json"
+        )
+
+        app = self.client.v3.apps.restart("app_id")
+        self.assertIsInstance(app, JsonObject)
+        self.assertEquals("my_app", app["name"])
+
     def test_remove(self):
         self.client.delete.return_value = self.mock_response("/v3/apps/app_id", HTTPStatus.NO_CONTENT, None)
         self.client.v3.apps.remove("app_id")


### PR DESCRIPTION
**[Get an app](https://v3-apidocs.cloudfoundry.org/version/3.103.0/index.html#get-an-app)** endpoint doesn't return the restart URL.

Hereby, we can not call the restart URL like this `self.client.v3.apps.get("app_id").restart()`

I added a helper function for the restart URL.

P.S.: **[Get an app](https://v3-apidocs.cloudfoundry.org/version/3.103.0/index.html#get-an-app)** and **[Restart an app](https://v3-apidocs.cloudfoundry.org/version/3.103.0/index.html#restart-an-app)** return same response. Therefore, I used `GET_{id}_response.json` file in the unit test.