### PR TITLE
Add missing dataclasses dependency for py 3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ websocket-client==0.54.0
 PyYAML==5.4.1
 requests>=2.5.0
 polling2==0.4.6
+dataclasses==0.8; python_version < '3.7'


### PR DESCRIPTION
Dataclasses was introduced with python 3.7. For python 3.6 there is a backport available which can be used. (https://pypi.org/project/dataclasses/)

