### PR TITLE
Fix relationships in domain create and org quotas

### DIFF
--- a/main/cloudfoundry_client/v3/domains.py
+++ b/main/cloudfoundry_client/v3/domains.py
@@ -34,8 +34,10 @@ class DomainManager(EntityManager):
         data = {
             "name": name,
             "internal": internal,
-            "organization": organization,
-            "shared_organizations": shared_organizations,
+            "relationships": {
+                "organization": organization,
+                "shared_organizations": shared_organizations,
+            },
             "metadata": {"labels": meta_labels, "annotations": meta_annotations},
         }
         return super(DomainManager, self)._create(data)

--- a/main/cloudfoundry_client/v3/organization_quotas.py
+++ b/main/cloudfoundry_client/v3/organization_quotas.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 from dataclasses import dataclass, asdict
 
 from cloudfoundry_client.v3.entities import Entity, EntityManager, ToManyRelationship
@@ -47,7 +47,7 @@ class OrganizationQuotaManager(EntityManager):
         services_quota: Optional[ServicesQuota] = None,
         routes_quota: Optional[RoutesQuota] = None,
         domains_quota: Optional[DomainsQuota] = None,
-        assigned_organizations: Optional[List[str]] = None,
+        assigned_organizations: Optional[ToManyRelationship] = None,
     ) -> Entity:
         data = self._asdict(name, apps_quota, services_quota, routes_quota, domains_quota, assigned_organizations)
         return super()._create(data)
@@ -64,10 +64,11 @@ class OrganizationQuotaManager(EntityManager):
         data = self._asdict(name, apps_quota, services_quota, routes_quota, domains_quota)
         return super()._update(guid, data)
 
-    def apply_to_organizations(self, guid: str, organization_guids: List[str]) -> ToManyRelationship:
-        data = ToManyRelationship(*organization_guids)
+    def apply_to_organizations(self, guid: str, organizations: ToManyRelationship) -> ToManyRelationship:
         return ToManyRelationship.from_json_object(
-            super()._post("%s%s/%s/relationships/organizations" % (self.target_endpoint, self.entity_uri, guid), data=data)
+            super()._post(
+                "%s%s/%s/relationships/organizations" % (self.target_endpoint, self.entity_uri, guid), data=organizations
+            )
         )
 
     def _asdict(
@@ -77,7 +78,7 @@ class OrganizationQuotaManager(EntityManager):
         services_quota: Optional[ServicesQuota] = None,
         routes_quota: Optional[RoutesQuota] = None,
         domains_quota: Optional[DomainsQuota] = None,
-        assigned_organizations: Optional[List[str]] = None,
+        assigned_organizations: Optional[ToManyRelationship] = None,
     ):
         data = {"name": name}
         if apps_quota:

--- a/test/v3/test_domains.py
+++ b/test/v3/test_domains.py
@@ -57,7 +57,7 @@ class TestDomains(unittest.TestCase, AbstractTestCase):
             "domain_id",
             internal=False,
             organization=ToOneRelationship("organization-guid"),
-            shared_organizations=None,
+            shared_organizations=ToManyRelationship("other-org-guid-1", "other-org-guid-2"),
             meta_labels=None,
             meta_annotations=None,
         )
@@ -67,8 +67,15 @@ class TestDomains(unittest.TestCase, AbstractTestCase):
             json={
                 "name": "domain_id",
                 "internal": False,
-                "organization": {"data": {"guid": "organization-guid"}},
-                "shared_organizations": None,
+                "relationships": {
+                    "organization": {"data": {"guid": "organization-guid"}},
+                    "shared_organizations": {
+                        "data": [
+                            {"guid": "other-org-guid-1"},
+                            {"guid": "other-org-guid-2"},
+                        ]
+                    },
+                },
                 "metadata": {"labels": None, "annotations": None},
             },
         )

--- a/test/v3/test_organization_quotas.py
+++ b/test/v3/test_organization_quotas.py
@@ -70,7 +70,7 @@ class TestOrganizationQuotas(unittest.TestCase, AbstractTestCase):
             services_quota=ServicesQuota(paid_services_allowed=True, total_service_instances=10, total_service_keys=20),
             routes_quota=RoutesQuota(total_routes=8, total_reserved_ports=4),
             domains_quota=DomainsQuota(total_domains=7),
-            assigned_organizations=["assigned-org"],
+            assigned_organizations=ToManyRelationship("assigned-org"),
         )
         self.client.post.assert_called_with(
             self.client.post.return_value.url,
@@ -81,7 +81,7 @@ class TestOrganizationQuotas(unittest.TestCase, AbstractTestCase):
                 "services": {"paid_services_allowed": True, "total_service_instances": 10, "total_service_keys": 20},
                 "routes": {"total_routes": 8, "total_reserved_ports": 4},
                 "domains": {"total_domains": 7},
-                "relationships": {"organizations": ["assigned-org"]},
+                "relationships": {"organizations": {"data": [{"guid": "assigned-org"}]}},
             },
         )
         self.assertIsNotNone(result)
@@ -97,7 +97,7 @@ class TestOrganizationQuotas(unittest.TestCase, AbstractTestCase):
         )
         result = self.client.v3.organization_quotas.apply_to_organizations(
             "quota_id",
-            organization_guids=["org-guid1", "org-guid2"],
+            organizations=ToManyRelationship("org-guid1", "org-guid2"),
         )
         self.client.post.assert_called_with(
             self.client.post.return_value.url, files=None, json={"data": [{"guid": "org-guid1"}, {"guid": "org-guid2"}]}


### PR DESCRIPTION
https://v3-apidocs.cloudfoundry.org/version/3.99.0/#create-a-domain show
that the organization/shared_organizations should be embedded in a
`relationships` field. I've added to the test some data for the
shared_organizations to make sure they serialize correctly too

Signed-off-by: Andy Paine <andrew.paine@sap.com>