### PR TITLE
Pin aiohttp>=3.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.7.4
+aiohttp>=3.8.0
 protobuf>=3.6.1
 oauth2-client==1.2.1
 websocket-client==0.54.0


### PR DESCRIPTION
Hi,

Here is a PR to pin aiohttp to >= 3.8.0. The reason is HTTP Header Injection vulnerability found in aiohttp: https://security.snyk.io/vuln/SNYK-PYTHON-AIOHTTP-1584144.


Thanks in advance!