### PR TITLE
update protobuf to version ==3.20.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp>=3.8.0
-protobuf>=3.19.0
+protobuf==3.20.1
 oauth2-client==1.2.1
 websocket-client==0.59.0
 PyYAML==6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp>=3.8.0
-protobuf>=3.6.1
+protobuf>=3.19.0
 oauth2-client==1.2.1
 websocket-client==0.59.0
 PyYAML==6.0


### PR DESCRIPTION
App deployment failing with below exception:
ERR   File "/home/vcap/deps/0/python/lib/python3.10/site-packages/cloudfoundry_client/client.py", line 9, in <module>
ERR     from cloudfoundry_client.doppler.client import DopplerClient
ERR   File "/home/vcap/deps/0/python/lib/python3.10/site-packages/cloudfoundry_client/doppler/client.py", line 10, in <module>
ERR     from cloudfoundry_client.dropsonde.envelope_pb2 import Envelope
ERR   File "/home/vcap/deps/0/python/lib/python3.10/site-packages/cloudfoundry_client/dropsonde/envelope_pb2.py", line 16, in <module>
ERR     import cloudfoundry_client.dropsonde.http_pb2 as http__pb2
ERR   File "/home/vcap/deps/0/python/lib/python3.10/site-packages/cloudfoundry_client/dropsonde/http_pb2.py", line 17, in <module>
ERR     import cloudfoundry_client.dropsonde.uuid_pb2 as uuid__pb2
ERR   File "/home/vcap/deps/0/python/lib/python3.10/site-packages/cloudfoundry_client/dropsonde/uuid_pb2.py", line 35, in <module>
ERR     _descriptor.FieldDescriptor(
ERR   File "/home/vcap/deps/0/python/lib/python3.10/site-packages/google/protobuf/descriptor.py", line 560, in __new__
ERR     _message.Message._CheckCalledFromGeneratedFile()
ERR TypeError: Descriptors cannot not be created directly.
ERR If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
ERR If you cannot immediately regenerate your protos, some other possible workarounds are:
ERR  1. Downgrade the protobuf package to 3.20.x or lower.
ERR  2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
ERR More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates

Hence pinning the module version to 3.20.1
