### PR TITLE
Bump oauth2-client to 1.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp>=3.8.0
 protobuf>=3.20.0, < 5.0.0dev
-oauth2-client==1.2.1
+oauth2-client~=1.3.0
 websocket-client~=1.3.1
 PyYAML==6.0
 requests>=2.5.0


### PR DESCRIPTION
The release seems to contain only minor fixes and this bump would help resolve conflicts with other libraries we are using. There seems to be no official changelog but the diff looks good: [1.2.1..1.3.0](https://github.com/antechrestos/OAuth2Client/compare/1.2.1...1.3.0). The biggest change is probably that python 3.6 is no longer supported, but this library doesn't support python 3.6 anyways.