### PR TITLE
Bump oauth2 client & add `user_agent` parameter

### DIFF
--- a/main/cloudfoundry_client/client.py
+++ b/main/cloudfoundry_client/client.py
@@ -138,6 +138,7 @@ class CloudFoundryClient(CredentialManager):
             The passed string has to be a URL-Encoded JSON Object, containing the field origin with value as origin_key
             of an identity provider. Note that this identity provider must support the grant type password.
             See UAA API specifications
+        :param user_agent: string. Can be used to set a custom http user agent
         """
         proxy = kwargs.get("proxy", dict(http="", https=""))
         verify = kwargs.get("verify", True)
@@ -150,7 +151,7 @@ class CloudFoundryClient(CredentialManager):
         service_information = ServiceInformation(
             None, "%s/oauth/token" % info.authorization_endpoint, client_id, client_secret, [], verify
         )
-        super(CloudFoundryClient, self).__init__(service_information, proxies=proxy)
+        super(CloudFoundryClient, self).__init__(service_information, proxies=proxy, user_agent=kwargs.get("user_agent"))
         self.v2 = V2(target_endpoint_trimmed, self)
         self.v3 = V3(target_endpoint_trimmed, self)
         self._doppler = (

--- a/main/cloudfoundry_client/client.py
+++ b/main/cloudfoundry_client/client.py
@@ -151,7 +151,11 @@ class CloudFoundryClient(CredentialManager):
         service_information = ServiceInformation(
             None, "%s/oauth/token" % info.authorization_endpoint, client_id, client_secret, [], verify
         )
-        super(CloudFoundryClient, self).__init__(service_information, proxies=proxy, user_agent=kwargs.get("user_agent"))
+        super(CloudFoundryClient, self).__init__(
+            service_information,
+            proxies=proxy,
+            user_agent=kwargs.get("user_agent", "cf-python-client")
+        )
         self.v2 = V2(target_endpoint_trimmed, self)
         self.v3 = V3(target_endpoint_trimmed, self)
         self._doppler = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp>=3.8.0
 protobuf>=3.20.0, < 5.0.0dev
-oauth2-client==1.2.1
+oauth2-client==1.4.0
 websocket-client~=1.3.1
 PyYAML==6.0
 requests>=2.5.0

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -60,8 +60,15 @@ class TestCloudfoundryClient(
             self.assertEqual("Bearer access-token", session.headers.get("Authorization"))
             requests.post.assert_called_with(
                 requests.post.return_value.url,
-                data=dict(grant_type="password", username="somebody", scope="", password="p@s$w0rd", token_format="opaque"),
-                headers=dict(Accept="application/json", Authorization="Basic Y2Y6"),
+                data=dict(
+                    grant_type="password",
+                    username="somebody",
+                    scope="",
+                    password="p@s$w0rd",
+                    token_format="opaque",
+                    client_id="cf",
+                ),
+                headers=dict(Accept="application/json"),
                 proxies=dict(http="", https=""),
                 verify=True,
             )
@@ -84,8 +91,10 @@ class TestCloudfoundryClient(
             self.assertEqual("Bearer access-token", session.headers.get("Authorization"))
             requests.post.assert_called_with(
                 requests.post.return_value.url,
-                data=dict(grant_type="refresh_token", scope="", refresh_token="refresh-token", token_format="opaque"),
-                headers=dict(Accept="application/json", Authorization="Basic Y2Y6"),
+                data=dict(
+                    grant_type="refresh_token", scope="", refresh_token="refresh-token", token_format="opaque", client_id="cf"
+                ),
+                headers=dict(Accept="application/json"),
                 proxies=dict(http="", https=""),
                 verify=True,
             )
@@ -112,8 +121,8 @@ class TestCloudfoundryClient(
             self.assertEqual("Bearer access-token", session.headers.get("Authorization"))
             requests.post.assert_called_with(
                 requests.post.return_value.url,
-                data=dict(grant_type="refresh_token", scope="", refresh_token="refresh-token"),
-                headers=dict(Accept="application/json", Authorization="Basic Y2Y6"),
+                data=dict(grant_type="refresh_token", scope="", refresh_token="refresh-token", client_id="cf"),
+                headers=dict(Accept="application/json"),
                 proxies=proxy,
                 verify=True,
             )
@@ -144,8 +153,9 @@ class TestCloudfoundryClient(
                     scope="",
                     password="p@s$w0rd",
                     login_hint="%7B%22origin%22%3A%22uaa%22%7D",
+                    client_id="cf",
                 ),
-                headers=dict(Accept="application/json", Authorization="Basic Y2Y6"),
+                headers=dict(Accept="application/json"),
                 proxies=dict(http="", https=""),
                 verify=True,
             )


### PR DESCRIPTION
- Bumps oauth2-client to latest version v1.4.0
  Including test adoptions to not check authorization header

- Implement `user_agent` parameter of oauth2-client. See https://github.com/antechrestos/OAuth2Client/pull/12