### PR TITLE
Add support for `GET /v3/service_instances/:guid/permissions`

### DIFF
--- a/main/cloudfoundry_client/v3/service_instances.py
+++ b/main/cloudfoundry_client/v3/service_instances.py
@@ -1,5 +1,6 @@
 from typing import Optional, TYPE_CHECKING, List
 
+from cloudfoundry_client.common_objects import JsonObject
 from cloudfoundry_client.v3.entities import Entity, EntityManager, ToOneRelationship
 
 if TYPE_CHECKING:
@@ -72,3 +73,8 @@ class ServiceInstanceManager(EntityManager):
 
     def remove(self, guid: str, asynchronous: bool = True):
         super(ServiceInstanceManager, self)._remove(guid, asynchronous)
+
+    def get_permissions(self, instance_guid: str) -> JsonObject:
+        return super(ServiceInstanceManager, self)._get(
+            "%s%s/%s/permissions" % (self.target_endpoint, self.entity_uri, instance_guid)
+        )

--- a/test/fixtures/v3/service_instances/GET_{id}_permissions_response.json
+++ b/test/fixtures/v3/service_instances/GET_{id}_permissions_response.json
@@ -1,0 +1,4 @@
+{
+  "read": true,
+  "manage": false
+}

--- a/test/v3/test_service_instances.py
+++ b/test/v3/test_service_instances.py
@@ -3,6 +3,7 @@ from http import HTTPStatus
 from unittest.mock import patch
 
 from abstract_test_case import AbstractTestCase
+from cloudfoundry_client.common_objects import JsonObject
 from cloudfoundry_client.v3.entities import Entity
 
 
@@ -157,3 +158,17 @@ class TestServiceInstances(unittest.TestCase, AbstractTestCase):
         self.client.v3.service_instances.remove("service_instance_id", asynchronous=False)
         self.client.delete.assert_called_with(self.client.delete.return_value.url)
         assert self.client.get.call_count == 2
+
+    def test_get_permissions(self):
+        self.client.get.return_value = self.mock_response(
+            "/v3/service_instances/service_instance_id/permissions",
+            HTTPStatus.OK,
+            None,
+            "v3",
+            "service_instances",
+            "GET_{id}_permissions_response.json"
+        )
+        permissions = self.client.v3.service_instances.get_permissions("service_instance_id")
+        self.assertIsInstance(permissions, JsonObject)
+        self.assertTrue(permissions["read"])
+        self.assertFalse(permissions["manage"])


### PR DESCRIPTION
https://v3-apidocs.cloudfoundry.org/version/3.138.0/index.html#get-permissions-for-a-service-instance