### PR TITLE
Update Python Version Support

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10","3.11","3.12"]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,7 @@ Supported versions
 - Starting version ``1.11.0``, versions older than python ``3.6.0`` will not be supported anymore. This late version was released by the end 2016.
   For those that are still using python 2.7, it won't be supported by the end of 2020 and all library shall stop supporting it.
 - Starting version ``1.25.0``, versions older than python ``3.7.0`` will not be supported anymore.
+- Starting version ``1.36.0``, versions older than python ``3.8.0`` will not be supported anymore.
 
 See `official documentation`_.
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
 black==22.12.0
 flake8==5.0.4
+setuptools; python_version >= '3.12'

--- a/setup.py
+++ b/setup.py
@@ -69,12 +69,12 @@ setup(
     description="A client library for CloudFoundry",
     long_description=open("README.rst").read(),
     url="http://github.com/antechrestos/cf-python-client",
+    python_requires=">=3.8",
     classifiers=[
         "Programming Language :: Python",
         "Natural Language :: English",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,8 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Communications",
     ],
     entry_points={

--- a/test/operations/push/test_push.py
+++ b/test/operations/push/test_push.py
@@ -41,7 +41,7 @@ class TestPushOperation(TestCase, AbstractTestCase):
 
     def test_to_host_should_remove_unwanted_characters(self):
         host = PushOperation._to_host("idzone-3.0.7-rec-tb1_bobby")
-        self.assertEquals("idzone-307-rec-tb1-bobby", host)
+        self.assertEqual("idzone-307-rec-tb1-bobby", host)
 
     @patch.object(
         sys,

--- a/test/v3/test_apps.py
+++ b/test/v3/test_apps.py
@@ -81,7 +81,7 @@ class TestApps(unittest.TestCase, AbstractTestCase):
 
         app = self.client.v3.apps.restart("app_id")
         self.assertIsInstance(app, JsonObject)
-        self.assertEquals("my_app", app["name"])
+        self.assertEqual("my_app", app["name"])
 
     def test_remove(self):
         self.client.delete.return_value = self.mock_response("/v3/apps/app_id", HTTPStatus.NO_CONTENT, None)
@@ -94,7 +94,7 @@ class TestApps(unittest.TestCase, AbstractTestCase):
         )
         env = self.client.v3.apps.get_env("app_id")
         self.assertIsInstance(env, JsonObject)
-        self.assertEquals(env["application_env_json"]["VCAP_APPLICATION"]["limits"]["fds"], 16384)
+        self.assertEqual(env["application_env_json"]["VCAP_APPLICATION"]["limits"]["fds"], 16384)
 
     def test_get_routes(self):
         self.client.get.return_value = self.mock_response(
@@ -102,7 +102,7 @@ class TestApps(unittest.TestCase, AbstractTestCase):
         )
         routes = self.client.v3.apps.get_routes("app_id")
         self.assertIsInstance(routes, JsonObject)
-        self.assertEquals(routes["resources"][0]["destinations"][0]["guid"], "385bf117-17f5-4689-8c5c-08c6cc821fed")
+        self.assertEqual(routes["resources"][0]["destinations"][0]["guid"], "385bf117-17f5-4689-8c5c-08c6cc821fed")
 
     def test_get_include_space_and_org(self):
         self.client.get.return_value = self.mock_response(


### PR DESCRIPTION
Python 3.7 is End of Life as of June 27th, 2023

Certain dependencies (e.g. `websocket-client`) have already dropped support for Python 3.7 and cannot be updated until support is dropped from this package.

*NOTE* I guessed the next version.  Change as needed.