### PR TITLE
fixes(api) allow no v2 api

### DIFF
--- a/cloudfoundry_client/common_objects.py
+++ b/cloudfoundry_client/common_objects.py
@@ -1,5 +1,5 @@
 import json
-from typing import Callable, TypeVar, Generic, List, Union
+from typing import Callable, TypeVar, Generic, List, Optional
 
 
 class Request(dict):
@@ -21,7 +21,7 @@ ENTITY = TypeVar('ENTITY')
 class Pagination(Generic[ENTITY]):
     def __init__(self, first_page: JsonObject,
                  total_result: int,
-                 next_page_loader: Callable[[JsonObject], Union[None, JsonObject]],
+                 next_page_loader: Callable[[JsonObject], Optional[JsonObject]],
                  resources_accessor: Callable[[JsonObject], List[JsonObject]],
                  instance_creator: Callable[[JsonObject], ENTITY]):
         self._first_page = first_page

--- a/cloudfoundry_client/v2/apps.py
+++ b/cloudfoundry_client/v2/apps.py
@@ -77,7 +77,7 @@ class AppManager(EntityManager):
 
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
         super(AppManager, self).__init__(
-            target_endpoint, client, "/v2/apps", lambda pairs: Application(target_endpoint, client, pairs)
+            target_endpoint, client, "/apps", lambda pairs: Application(target_endpoint, client, pairs)
         )
 
     def get_stats(self, application_guid: str) -> Dict[str, JsonObject]:

--- a/cloudfoundry_client/v2/buildpacks.py
+++ b/cloudfoundry_client/v2/buildpacks.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 class BuildpackManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(BuildpackManager, self).__init__(target_endpoint, client, "/v2/buildpacks")
+        super(BuildpackManager, self).__init__(target_endpoint, client, "/buildpacks")
 
     def update(self, buildpack_guid: str, parameters: dict) -> Entity:
         return super(BuildpackManager, self)._update(buildpack_guid, parameters)

--- a/cloudfoundry_client/v2/entities.py
+++ b/cloudfoundry_client/v2/entities.py
@@ -1,5 +1,5 @@
 from functools import partial, reduce
-from typing import Callable, List, Tuple, Any, Optional, TYPE_CHECKING, Union
+from typing import Callable, List, Tuple, Any, Optional, TYPE_CHECKING
 from urllib.parse import quote
 from requests import Response
 
@@ -68,7 +68,7 @@ class EntityManager(object):
                           lambda page: page["resources"],
                           lambda json_object: current_builder(list(json_object.items())))
 
-    def _next_page(self, current_page: JsonObject) -> Union[None, JsonObject]:
+    def _next_page(self, current_page: JsonObject) -> Optional[JsonObject]:
         next_url = current_page.get("next_url")
         if next_url is None:
             return None

--- a/cloudfoundry_client/v2/events.py
+++ b/cloudfoundry_client/v2/events.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 class EventManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(EventManager, self).__init__(target_endpoint, client, "/v2/events")
+        super(EventManager, self).__init__(target_endpoint, client, "/events")
 
     def list_by_type(self, event_type: str) -> Generator[Entity, None, None]:
         return self._list(self.entity_uri, type=event_type)

--- a/cloudfoundry_client/v2/jobs.py
+++ b/cloudfoundry_client/v2/jobs.py
@@ -12,4 +12,4 @@ class JobManager(object):
         self.client = client
 
     def get(self, job_guid: str) -> JsonObject:
-        return self.client.get("%s/v2/jobs/%s" % (self.target_endpoint, job_guid)).json(object_pairs_hook=JsonObject)
+        return self.client.get("%s/jobs/%s" % (self.target_endpoint, job_guid)).json(object_pairs_hook=JsonObject)

--- a/cloudfoundry_client/v2/resources.py
+++ b/cloudfoundry_client/v2/resources.py
@@ -12,5 +12,5 @@ class ResourceManager(object):
         self.client = client
 
     def match(self, items: List[dict]) -> List[JsonObject]:
-        response = self.client.put("%s/v2/resource_match" % self.client.info.api_endpoint, json=items)
+        response = self.client.put("%s/resource_match" % self.client.info.api_endpoint, json=items)
         return response.json(object_pairs_hook=JsonObject)

--- a/cloudfoundry_client/v2/routes.py
+++ b/cloudfoundry_client/v2/routes.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 class RouteManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(RouteManager, self).__init__(target_endpoint, client, "/v2/routes")
+        super(RouteManager, self).__init__(target_endpoint, client, "/routes")
 
     def create_tcp_route(self, domain_guid: str, space_guid: str, port: Optional[int] = None) -> Entity:
         request = self._request(domain_guid=domain_guid, space_guid=space_guid)

--- a/cloudfoundry_client/v2/service_bindings.py
+++ b/cloudfoundry_client/v2/service_bindings.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 class ServiceBindingManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(ServiceBindingManager, self).__init__(target_endpoint, client, "/v2/service_bindings")
+        super(ServiceBindingManager, self).__init__(target_endpoint, client, "/service_bindings")
 
     def create(self, app_guid: str, instance_guid: str, parameters: Optional[dict] = None, name: Optional[str] = None) -> Entity:
         request = self._request(app_guid=app_guid, service_instance_guid=instance_guid)

--- a/cloudfoundry_client/v2/service_brokers.py
+++ b/cloudfoundry_client/v2/service_brokers.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 class ServiceBrokerManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(ServiceBrokerManager, self).__init__(target_endpoint, client, "/v2/service_brokers")
+        super(ServiceBrokerManager, self).__init__(target_endpoint, client, "/service_brokers")
 
     def create(
         self, broker_url: str, broker_name: str, auth_username: str, auth_password: str, space_guid: Optional[str] = None

--- a/cloudfoundry_client/v2/service_instances.py
+++ b/cloudfoundry_client/v2/service_instances.py
@@ -10,7 +10,7 @@ class ServiceInstanceManager(EntityManager):
     list_query_parameters = ["page", "results-per-page", "order-direction", "return_user_provided_service_instances"]
 
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(ServiceInstanceManager, self).__init__(target_endpoint, client, "/v2/service_instances")
+        super(ServiceInstanceManager, self).__init__(target_endpoint, client, "/service_instances")
 
     def create(
         self,

--- a/cloudfoundry_client/v2/service_keys.py
+++ b/cloudfoundry_client/v2/service_keys.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 class ServiceKeyManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(ServiceKeyManager, self).__init__(target_endpoint, client, "/v2/service_keys")
+        super(ServiceKeyManager, self).__init__(target_endpoint, client, "/service_keys")
 
     def create(self, service_instance_guid: str, name: str, parameters: Optional[dict] = None) -> Entity:
         request = self._request(service_instance_guid=service_instance_guid, name=name)

--- a/cloudfoundry_client/v2/service_plan_visibilities.py
+++ b/cloudfoundry_client/v2/service_plan_visibilities.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 class ServicePlanVisibilityManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(ServicePlanVisibilityManager, self).__init__(target_endpoint, client, "/v2/service_plan_visibilities")
+        super(ServicePlanVisibilityManager, self).__init__(target_endpoint, client, "/service_plan_visibilities")
 
     def create(self, service_plan_guid: str, organization_guid: str) -> Entity:
         request = self._request()

--- a/cloudfoundry_client/v2/service_plans.py
+++ b/cloudfoundry_client/v2/service_plans.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 class ServicePlanManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(ServicePlanManager, self).__init__(target_endpoint, client, "/v2/service_plans")
+        super(ServicePlanManager, self).__init__(target_endpoint, client, "/service_plans")
 
     def create_from_resource_file(self, path: str) -> Entity:
         raise NotImplementedError("No creation allowed")

--- a/cloudfoundry_client/v2/spaces.py
+++ b/cloudfoundry_client/v2/spaces.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 class SpaceManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(SpaceManager, self).__init__(target_endpoint, client, "/v2/spaces")
+        super(SpaceManager, self).__init__(target_endpoint, client, "/spaces")
 
     def delete_unmapped_routes(self, space_guid: str):
         url = "%s%s/%s/unmapped_routes" % (self.target_endpoint, self.entity_uri, space_guid)

--- a/cloudfoundry_client/v3/apps.py
+++ b/cloudfoundry_client/v3/apps.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 class AppManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(AppManager, self).__init__(target_endpoint, client, "/v3/apps")
+        super(AppManager, self).__init__(target_endpoint, client, "/apps")
 
     def restart(self, application_guid: str):
         return super(AppManager, self)._post("%s%s/%s/actions/restart" % (self.target_endpoint,

--- a/cloudfoundry_client/v3/buildpacks.py
+++ b/cloudfoundry_client/v3/buildpacks.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 class BuildpackManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(BuildpackManager, self).__init__(target_endpoint, client, "/v3/buildpacks")
+        super(BuildpackManager, self).__init__(target_endpoint, client, "/buildpacks")
 
     def create(
         self,

--- a/cloudfoundry_client/v3/domains.py
+++ b/cloudfoundry_client/v3/domains.py
@@ -21,7 +21,7 @@ class Domain(Entity):
 
 class DomainManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(DomainManager, self).__init__(target_endpoint, client, "/v3/domains", Domain)
+        super(DomainManager, self).__init__(target_endpoint, client, "/domains", Domain)
 
     def create(
         self,
@@ -44,7 +44,7 @@ class DomainManager(EntityManager):
         return super(DomainManager, self)._create(data)
 
     def list_domains_for_org(self, org_guid: str, **kwargs) -> Pagination[Entity]:
-        uri = "/v3/organizations/{guid}/domains".format(guid=org_guid)
+        uri = "/organizations/{guid}/domains".format(guid=org_guid)
         return self._list(uri, **kwargs)
 
     def update(self, domain_guid: str, meta_labels: Optional[dict] = None, meta_annotations: Optional[dict] = None) -> Domain:

--- a/cloudfoundry_client/v3/entities.py
+++ b/cloudfoundry_client/v3/entities.py
@@ -188,7 +188,7 @@ class EntityManager(object):
                           lambda p: p["resources"],
                           _entity)
 
-    def _next_page(self, current_page: JsonObject) -> Union[None, JsonObject]:
+    def _next_page(self, current_page: JsonObject) -> Optional[JsonObject]:
         pagination = current_page.get("pagination")
         if (
                 pagination is None

--- a/cloudfoundry_client/v3/feature_flags.py
+++ b/cloudfoundry_client/v3/feature_flags.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 class FeatureFlagManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(FeatureFlagManager, self).__init__(target_endpoint, client, "/v3/feature_flags")
+        super(FeatureFlagManager, self).__init__(target_endpoint, client, "/feature_flags")
 
     def update(self, name: str, enabled: Optional[bool] = True, custom_error_message: Optional[str] = None) -> Entity:
         data = {"enabled": enabled, "custom_error_message": custom_error_message}

--- a/cloudfoundry_client/v3/isolation_segments.py
+++ b/cloudfoundry_client/v3/isolation_segments.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 class IsolationSegmentManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(IsolationSegmentManager, self).__init__(target_endpoint, client, "/v3/isolation_segments")
+        super(IsolationSegmentManager, self).__init__(target_endpoint, client, "/isolation_segments")
 
     def create(self, name: str, meta_labels: Optional[dict] = None, meta_annotations: Optional[dict] = None) -> Entity:
         data = {"name": name, "metadata": {"labels": meta_labels, "annotations": meta_annotations}}

--- a/cloudfoundry_client/v3/jobs.py
+++ b/cloudfoundry_client/v3/jobs.py
@@ -15,7 +15,7 @@ class JobTimeout(Exception):
 
 class JobManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(JobManager, self).__init__(target_endpoint, client, "/v3/jobs")
+        super(JobManager, self).__init__(target_endpoint, client, "/jobs")
 
     def wait_for_job_completion(
         self,

--- a/cloudfoundry_client/v3/organization_quotas.py
+++ b/cloudfoundry_client/v3/organization_quotas.py
@@ -35,7 +35,7 @@ class DomainsQuota:
 
 class OrganizationQuotaManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super().__init__(target_endpoint, client, "/v3/organization_quotas")
+        super().__init__(target_endpoint, client, "/organization_quotas")
 
     def remove(self, guid: str, asynchronous: bool = True) -> Optional[str]:
         return super()._remove(guid, asynchronous)

--- a/cloudfoundry_client/v3/organizations.py
+++ b/cloudfoundry_client/v3/organizations.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 class OrganizationManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(OrganizationManager, self).__init__(target_endpoint, client, "/v3/organizations")
+        super(OrganizationManager, self).__init__(target_endpoint, client, "/organizations")
 
     def create(
         self, name: str, suspended: bool, meta_labels: Optional[dict] = None, meta_annotations: Optional[dict] = None

--- a/cloudfoundry_client/v3/processes.py
+++ b/cloudfoundry_client/v3/processes.py
@@ -8,4 +8,4 @@ if TYPE_CHECKING:
 
 class ProcessManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(ProcessManager, self).__init__(target_endpoint, client, "/v3/processes")
+        super(ProcessManager, self).__init__(target_endpoint, client, "/processes")

--- a/cloudfoundry_client/v3/roles.py
+++ b/cloudfoundry_client/v3/roles.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 class RoleManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(RoleManager, self).__init__(target_endpoint, client, "/v3/roles")
+        super(RoleManager, self).__init__(target_endpoint, client, "/roles")
 
     def remove(self, role_guid: str, asynchronous: bool = True) -> Optional[str]:
         return super(RoleManager, self)._remove(role_guid, asynchronous)

--- a/cloudfoundry_client/v3/security_groups.py
+++ b/cloudfoundry_client/v3/security_groups.py
@@ -37,7 +37,7 @@ class GloballyEnabled:
 
 class SecurityGroupManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(SecurityGroupManager, self).__init__(target_endpoint, client, "/v3/security_groups")
+        super(SecurityGroupManager, self).__init__(target_endpoint, client, "/security_groups")
 
     def create(self,
                name: str,

--- a/cloudfoundry_client/v3/service_brokers.py
+++ b/cloudfoundry_client/v3/service_brokers.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 class ServiceBrokerManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(ServiceBrokerManager, self).__init__(target_endpoint, client, "/v3/service_brokers")
+        super(ServiceBrokerManager, self).__init__(target_endpoint, client, "/service_brokers")
 
     def create(
         self,

--- a/cloudfoundry_client/v3/service_credential_bindings.py
+++ b/cloudfoundry_client/v3/service_credential_bindings.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 class ServiceCredentialBindingManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
         super(ServiceCredentialBindingManager, self).__init__(target_endpoint, client,
-                                                              "/v3/service_credential_bindings")
+                                                              "/service_credential_bindings")
 
     def create(
             self,

--- a/cloudfoundry_client/v3/service_instances.py
+++ b/cloudfoundry_client/v3/service_instances.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 class ServiceInstanceManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(ServiceInstanceManager, self).__init__(target_endpoint, client, "/v3/service_instances")
+        super(ServiceInstanceManager, self).__init__(target_endpoint, client, "/service_instances")
 
     def create(
         self,

--- a/cloudfoundry_client/v3/service_offerings.py
+++ b/cloudfoundry_client/v3/service_offerings.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 class ServiceOfferingsManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(ServiceOfferingsManager, self).__init__(target_endpoint, client, "/v3/service_offerings")
+        super(ServiceOfferingsManager, self).__init__(target_endpoint, client, "/service_offerings")
 
     def update(self, guid: str, meta_labels: Optional[dict] = None, meta_annotations: Optional[dict] = None) -> Entity:
         payload = dict()

--- a/cloudfoundry_client/v3/service_plans.py
+++ b/cloudfoundry_client/v3/service_plans.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 class ServicePlanManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(ServicePlanManager, self).__init__(target_endpoint, client, "/v3/service_plans")
+        super(ServicePlanManager, self).__init__(target_endpoint, client, "/service_plans")
 
     def update(
         self,

--- a/cloudfoundry_client/v3/spaces.py
+++ b/cloudfoundry_client/v3/spaces.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 class SpaceManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(SpaceManager, self).__init__(target_endpoint, client, "/v3/spaces")
+        super(SpaceManager, self).__init__(target_endpoint, client, "/spaces")
 
     def create(self, name: str, org_guid: str) -> Entity:
         return super(SpaceManager, self)._create(dict(name=name, relationships=dict(organization=ToOneRelationship(org_guid))))

--- a/cloudfoundry_client/v3/tasks.py
+++ b/cloudfoundry_client/v3/tasks.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 class TaskManager(EntityManager):
     def __init__(self, target_endpoint: str, client: "CloudFoundryClient"):
-        super(TaskManager, self).__init__(target_endpoint, client, "/v3/tasks")
+        super(TaskManager, self).__init__(target_endpoint, client, "/tasks")
 
     def create(
         self,
@@ -24,7 +24,7 @@ class TaskManager(EntityManager):
         request["disk_in_mb"] = disk_in_mb
         request["memory_in_mb"] = memory_in_mb
         request["droplet_guid"] = droplet_guid
-        return self._post("%s/v3/apps/%s/tasks" % (self.target_endpoint, application_guid), data=request)
+        return self._post("%s/apps/%s/tasks" % (self.target_endpoint, application_guid), data=request)
 
     def cancel(self, task_guid: str) -> Entity:
-        return self._post("%s/v3/tasks/%s/actions/cancel" % (self.target_endpoint, task_guid))
+        return self._post("%s/tasks/%s/actions/cancel" % (self.target_endpoint, task_guid))

--- a/tests/abstract_test_case.py
+++ b/tests/abstract_test_case.py
@@ -30,8 +30,6 @@ class AbstractTestCase(object):
     TOKEN_ENDPOINT = "http://token.somewhere.org"
     DOPPLER_ENDPOINT = "wss://doppler.nd-cfapi.itn.ftgroup:443"
     LOG_STREAM_ENDPOINT = "https://log-stream.nd-cfapi.itn.ftgroup"
-    API_V2_VERSION = "2.141.0"
-    API_V3_VERSION = "3.76.0"
 
     @classmethod
     def mock_client_class(cls):
@@ -43,33 +41,40 @@ class AbstractTestCase(object):
             self.client = CloudFoundryClient(self.TARGET_ENDPOINT)
 
     @staticmethod
-    def _mock_info_calls(requests, with_doppler: bool = True, with_log_streams: bool = True):
+    def _mock_info_calls(
+            requests,
+            with_doppler: bool = True,
+            with_log_streams: bool = True,
+            with_v2: bool = True,
+            with_v3: bool = True
+    ):
+        links = {
+            "self": dict(href=AbstractTestCase.TARGET_ENDPOINT),
+            "cloud_controller_v2": dict(
+                href="%s/v2" % AbstractTestCase.TARGET_ENDPOINT,
+                meta=dict(version="2.141.0"),
+            ),
+            "cloud_controller_v3": dict(
+                href="%s/v3" % AbstractTestCase.TARGET_ENDPOINT,
+                meta=dict(version="3.76.0"),
+            ),
+            "logging": dict(href=AbstractTestCase.DOPPLER_ENDPOINT) if with_doppler else None,
+            "log_stream": dict(href=AbstractTestCase.LOG_STREAM_ENDPOINT) if with_log_streams else None,
+            "app_ssh": dict(href="ssh.nd-cfapi.itn.ftgroup:80"),
+            "uaa": dict(href="https://uaa.nd-cfapi.itn.ftgroup"),
+            "login": dict(href=AbstractTestCase.AUTHORIZATION_ENDPOINT),
+            "network_policy_v0": dict(href="https://api.nd-cfapi.itn.ftgroup/networking/v0/external"),
+            "network_policy_v1": dict(href="https://api.nd-cfapi.itn.ftgroup/networking/v1/external"),
+        }
+        if not with_v2:
+            del links["cloud_controller_v2"]
+        if not with_v3:
+            del links["cloud_controller_v3"]
         requests.get.side_effect = [
             MockResponse(
                 "%s/" % AbstractTestCase.TARGET_ENDPOINT,
                 status_code=HTTPStatus.OK.value,
-                text=json.dumps(
-                    dict(
-                        links={
-                            "self": dict(href=AbstractTestCase.TARGET_ENDPOINT),
-                            "cloud_controller_v2": dict(
-                                href="%s/v2" % AbstractTestCase.TARGET_ENDPOINT,
-                                meta=dict(version=AbstractTestCase.API_V2_VERSION),
-                            ),
-                            "cloud_controller_v3": dict(
-                                href="%s/v3" % AbstractTestCase.TARGET_ENDPOINT,
-                                meta=dict(version=AbstractTestCase.API_V3_VERSION),
-                            ),
-                            "logging": dict(href=AbstractTestCase.DOPPLER_ENDPOINT) if with_doppler else None,
-                            "log_stream": dict(href=AbstractTestCase.LOG_STREAM_ENDPOINT) if with_log_streams else None,
-                            "app_ssh": dict(href="ssh.nd-cfapi.itn.ftgroup:80"),
-                            "uaa": dict(href="https://uaa.nd-cfapi.itn.ftgroup"),
-                            "login": dict(href=AbstractTestCase.AUTHORIZATION_ENDPOINT),
-                            "network_policy_v0": dict(href="https://api.nd-cfapi.itn.ftgroup/networking/v0/external"),
-                            "network_policy_v1": dict(href="https://api.nd-cfapi.itn.ftgroup/networking/v1/external"),
-                        }
-                    )
-                ),
+                text=json.dumps(dict(links=links)),
             ),
         ]
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -42,6 +42,28 @@ class TestCloudfoundryClient(
             client = CloudFoundryClient(self.TARGET_ENDPOINT, token_format="opaque")
             self.assertRaises(NotImplementedError, lambda: client.doppler)
 
+    def test_build_client_when_no_v2(self):
+        requests = FakeRequests()
+        session = MockSession()
+        with patch("oauth2_client.credentials_manager.requests", new=requests), patch(
+            "cloudfoundry_client.client.requests", new=requests
+        ):
+            requests.Session.return_value = session
+            self._mock_info_calls(requests, with_v2=False)
+            client = CloudFoundryClient(self.TARGET_ENDPOINT, token_format="opaque")
+            self.assertRaises(NotImplementedError, lambda: client.v2)
+
+    def test_build_client_when_no_v3(self):
+        requests = FakeRequests()
+        session = MockSession()
+        with patch("oauth2_client.credentials_manager.requests", new=requests), patch(
+            "cloudfoundry_client.client.requests", new=requests
+        ):
+            requests.Session.return_value = session
+            self._mock_info_calls(requests, with_v3=False)
+            client = CloudFoundryClient(self.TARGET_ENDPOINT, token_format="opaque")
+            self.assertRaises(NotImplementedError, lambda: client.v3)
+
     def test_grant_password_request_with_token_format_opaque(self):
         requests = FakeRequests()
         session = MockSession()
@@ -162,7 +184,8 @@ class TestCloudfoundryClient(
             self._mock_info_calls(requests)
             info = client._get_info(self.TARGET_ENDPOINT)
             self.assertEqual(info.api_endpoint, self.TARGET_ENDPOINT)
-            self.assertEqual(info.api_v2_version, self.API_V2_VERSION)
+            self.assertEqual(info.api_v2_url, "%s/v2" % self.TARGET_ENDPOINT)
+            self.assertEqual(info.api_v3_url, "%s/v3" % self.TARGET_ENDPOINT)
             self.assertEqual(info.doppler_endpoint, self.DOPPLER_ENDPOINT)
             self.assertEqual(info.log_stream_endpoint, self.LOG_STREAM_ENDPOINT)
 


### PR DESCRIPTION
* allow client without no V2 api
* stop supporting python 3.8 (EOL reached)
* support python 3.13
* use `cloud_controller_v2.href` and `cloud_controller_v3.href` from [root api call](https://v3-apidocs.cloudfoundry.org/version/3.184.0/index.html#global-api-root) to determine API base url 

Closes #220

