### PR TITLE
Fix: Ensure correct handling of `_included` entities in `Entity` class

### DIFF
--- a/cloudfoundry_client/v3/entities.py
+++ b/cloudfoundry_client/v3/entities.py
@@ -48,7 +48,7 @@ class Entity(JsonObject):
             other_manager = getattr(v3_client, manager_name, default_manager)
             entity_type = other_manager._get_entity_type(entity_name)
             entity = entity_type(other_manager.target_endpoint, other_manager.client, **entity_data)
-            setattr(self, entity_name, lambda: entity)
+            setattr(self, entity_name, functools.partial(lambda e: e, entity))
         self.pop("_included", None)
 
     @staticmethod


### PR DESCRIPTION
# Background

I encountered this issue while calling the `roles.list` method with the `include` parameter, specifically:

```python
roles = self.client.v3.roles.list(space_guids=[xxx], types=["space_developer", "space_manager", "space_auditor", "space_supporter"], include=["user", "space"])

for role in roles:
    user = role.user()
    space = role.space()
```
When iterating over the returned `roles` object, I attempted to access the included `user` and `space` data using dynamically generated methods, such as `role.user()` and `role.space()`. However, I noticed that these methods did not return the correct associated data. Instead, both methods returned the same data, corresponding to the last entity processed in the `_included` dictionary.

# Root Cause:  
The problematic line of code is:  
```python
setattr(self, entity_name, lambda: entity)
```
Here, the `lambda` function captures the variable `entity` by reference. Since `entity` is updated during each iteration of the loop, all dynamically created methods (e.g., `role.user()` and `role.space()`) share the same reference to `entity`. As a result, after the loop completes, all methods return the data of the last processed entity.

# Solution:  
To fix this issue, I replaced the `lambda` with `functools.partial`, which binds the current value of `entity` to the dynamically created method. This ensures that each method maintains an independent reference to the correct `entity` value.

If you have any suggestions, or need additional details about the fix, please feel free to contact me. I'm happy to provide further clarification or make additional changes if necessary.

Looking forward to your feedback and I hope this contribution can help improve the project! 
