### PR TITLE
feat: Add function to list organization domains

### DIFF
--- a/cloudfoundry_client/v3/organizations.py
+++ b/cloudfoundry_client/v3/organizations.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from cloudfoundry_client.common_objects import Pagination
 from cloudfoundry_client.v3.entities import EntityManager, Entity, ToOneRelationship
 
 if TYPE_CHECKING:
@@ -46,6 +47,10 @@ class OrganizationManager(EntityManager[Entity]):
         return ToOneRelationship.from_json_object(
             super().get(guid, "relationships", "default_isolation_segment")
         )
+
+    def list_domains(self, guid: str, **kwargs) -> Pagination[Entity]:
+        uri: str = "%s/%s/domains" % (self.entity_uri, guid)
+        return super()._list(requested_path=uri, **kwargs)
 
     def get_default_domain(self, guid: str) -> Entity:
         return super().get(guid, "domains", "default")

--- a/tests/fixtures/v3/organizations/GET_{id}_domains_response.json
+++ b/tests/fixtures/v3/organizations/GET_{id}_domains_response.json
@@ -1,0 +1,48 @@
+{
+  "pagination": {
+    "total_results": 1,
+    "total_pages": 1,
+    "first": {
+      "href": "https://api.example.org/v3/organizations/016b770b-b447-4a12-800a-1b4c69406a9f/domains?page=1&per_page=50"
+    },
+    "last": {
+      "href": "https://api.example.org/v3/organizations/016b770b-b447-4a12-800a-1b4c69406a9f/domains?page=1&per_page=50"
+    },
+    "next": null,
+    "previous": null
+  },
+  "resources": [
+    {
+      "guid": "3a5d3d89-3f89-4f05-8188-8a2b298c79d5",
+      "created_at": "2019-03-08T01:06:19Z",
+      "updated_at": "2019-03-08T01:06:19Z",
+      "name": "test-domain.com",
+      "internal": false,
+      "router_group": { "guid": "5806148f-cce6-4d86-7fbd-aa269e3f6f3f" },
+      "supported_protocols": ["tcp"],
+      "metadata": {
+        "labels": {},
+        "annotations": {}
+      },
+      "relationships": {
+        "organization": {
+          "data": null
+        },
+        "shared_organizations": {
+          "data": []
+        }
+      },
+      "links": {
+        "self": {
+          "href": "https://api.example.org/v3/domains/016b770b-b447-4a12-800a-1b4c69406a9f"
+        },
+        "route_reservations": {
+          "href": "https://api.example.org/v3/domains/016b770b-b447-4a12-800a-1b4c69406a9f/route_reservations"
+        },
+        "router_group": {
+          "href": "https://api.example.org/routing/v1/router_groups/5806148f-cce6-4d86-7fbd-aa269e3f6f3f"
+        }
+      }
+    }
+  ]
+}

--- a/tests/v3/test_organizations.py
+++ b/tests/v3/test_organizations.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 
 import cloudfoundry_client.main.main as main
 from abstract_test_case import AbstractTestCase
+
+from cloudfoundry_client.common_objects import Pagination
 from cloudfoundry_client.v3.entities import Entity, ToOneRelationship
 
 
@@ -143,6 +145,25 @@ class TestOrganizations(unittest.TestCase, AbstractTestCase):
         )
         self.client.v3.organizations.get_usage_summary("organization_id")
         self.client.get.assert_called_with(self.client.get.return_value.url)
+
+    def test_get_domains(self):
+        self.client.get.return_value = self.mock_response(
+            "/v3/organizations/organization_id/domains",
+            HTTPStatus.OK,
+            {"Content-Type": "application/json"},
+            "v3",
+            "organizations",
+            "GET_{id}_domains_response.json",
+        )
+        organization_domains_response: Pagination[Entity] = self.client.v3.organizations.list_domains("organization_id")
+        domains: list[dict] = [domain for domain in organization_domains_response]
+        print(domains)
+        self.assertIsInstance(domains, list)
+        self.assertEqual(len(domains), 1)
+        domain: dict = domains[0]
+        self.assertIsInstance(domain, dict)
+        self.assertEqual(domain.get("guid"), "3a5d3d89-3f89-4f05-8188-8a2b298c79d5")
+        self.assertEqual(domain.get("name"), "test-domain.com")
 
     @patch.object(sys, "argv", ["main", "list_organizations"])
     def test_main_list_organizations(self):


### PR DESCRIPTION
Added support for the [List Organization Domains](https://v3-apidocs.cloudfoundry.org/version/3.209.0/index.html#list-domains-for-an-organization) endpoint and the respective unit tests.